### PR TITLE
IDEM-1888: Part3 fix the sqs queue send message failure

### DIFF
--- a/lib/publisher/sqsapppublisher.go
+++ b/lib/publisher/sqsapppublisher.go
@@ -5,7 +5,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 )
@@ -49,9 +48,8 @@ func (s *sqsAppPublisherService) Publish(event AppChangeEvent) error {
 
 	log.Infof("Publishing the message for app type: %v", event.AppType)
 	_, err = s.sqsService.SendMessage(&sqs.SendMessageInput{
-		MessageDeduplicationId: aws.String(uuid.New().String()),
-		MessageBody:            aws.String(string(messageJsonData)),
-		QueueUrl:               queueUrlOutput.QueueUrl,
+		MessageBody: aws.String(string(messageJsonData)),
+		QueueUrl:    queueUrlOutput.QueueUrl,
 	})
 
 	if err != nil {


### PR DESCRIPTION
- Standard sqs queue does not allow the messageDeduplicationId to be sent as
part of sendMessage request its only applies to FIFO queue
- We are using the standard sqs queue, as the at least once delivery is good enough for us to process the changes.