### PR TITLE
IDEM-1930: Added AuditPublisher to publish audit events

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -648,6 +648,10 @@ func applyAuthConfig(fc *FileConfig, cfg *service.Config) error {
 	if err := applyAppPublisherConfig(fc, cfg); err != nil {
 		return trace.Wrap(err)
 	}
+
+	if err := applyAuditPublisherConfig(fc, cfg); err != nil {
+		return trace.Wrap(err)
+	}
 	return nil
 }
 
@@ -713,6 +717,26 @@ func applyAppPublisherConfig(fc *FileConfig, cfg *service.Config) error {
 	}
 
 	cfg.Auth.AppPublisherConfig.SQSQueueName = fc.Auth.AppPublisherConfig.SQSQueueName
+	return nil
+}
+
+func applyAuditPublisherConfig(fc *FileConfig, cfg *service.Config) error {
+	if fc.Auth.AuditPublisherConfig == nil {
+		cfg.Auth.AuditPublisherConfig.SQSQueueName = ""
+		return nil
+	}
+
+	enabled, _ := apiutils.ParseBool(fc.Auth.AuditPublisherConfig.Enabled)
+	cfg.Auth.AuditPublisherConfig.Enabled = enabled
+	cfg.Auth.AuditPublisherConfig.SQSQueueName = fc.Auth.AuditPublisherConfig.SQSQueueName
+	if len(fc.Auth.AuditPublisherConfig.EventTypes) > 0 {
+		eventByTypes := make(map[string]string)
+		for _, eventType := range fc.Auth.AuditPublisherConfig.EventTypes {
+			eventByTypes[eventType] = eventType
+		}
+		cfg.Auth.AuditPublisherConfig.EventByTypes = eventByTypes
+	}
+
 	return nil
 }
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -716,10 +716,19 @@ type Auth struct {
 	TunnelStrategy *types.TunnelStrategyV1 `yaml:"tunnel_strategy,omitempty"`
 
 	AppPublisherConfig *AppPublisherConfig `yaml:"app_publisher_config,omitempty"`
+
+	AuditPublisherConfig *AuditPublisherConfig `yaml:"audit_publisher_config,omitempty"`
 }
 
 type AppPublisherConfig struct {
 	SQSQueueName string `yaml:"sqs_queue_name,omitempty"`
+}
+
+type AuditPublisherConfig struct {
+	Enabled      string `yaml:"enabled,omitempty"`
+	SQSQueueName string `yaml:"sqs_queue_name,omitempty"`
+	// EventTypes audit event types are published using this publisher.
+	EventTypes apiutils.Strings `yaml:"event_types,omitempty"`
 }
 
 // CAKeyParams configures how CA private keys will be created and stored.

--- a/lib/publisher/auditpublisher.go
+++ b/lib/publisher/auditpublisher.go
@@ -1,0 +1,108 @@
+package publisher
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/cloudflare/cfssl/log"
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/trace"
+)
+
+const (
+	//default sqs queue name
+	defaultAuditSQSQueueName = "remote-access-audit-event-notification-queue"
+)
+
+type AuditPublisher interface {
+	apievents.Emitter
+}
+
+type AuditPublisherConfig struct {
+	Enabled      bool
+	SQSQueueName string
+	EventByTypes map[string]string
+}
+
+type AuditPublisherService struct {
+	publisher AuditMessagePublisher
+	cfg       AuditPublisherConfig
+}
+
+type AuditMessage struct {
+	MessageBody string
+}
+
+// AuditMessagePublisher responsible for publish the audit message to destination
+type AuditMessagePublisher interface {
+	Publish(audit AuditMessage) error
+}
+
+func (cfg *AuditPublisherConfig) CheckAndSetDefaults() error {
+	if cfg.SQSQueueName == "" {
+		cfg.SQSQueueName = defaultAuditSQSQueueName
+	}
+
+	if len(cfg.EventByTypes) == 0 {
+		cfg.EventByTypes = getDefaultEventByTypes()
+	}
+	return nil
+}
+
+func NewAuditPublisher(cfg AuditPublisherConfig) AuditPublisher {
+	if cfg.Enabled {
+		log.Info("Audit publishing is eanbled")
+		cfg.CheckAndSetDefaults()
+		return &AuditPublisherService{
+			publisher: NewAuditMessagePublisherService(cfg),
+			cfg:       cfg,
+		}
+	}
+	log.Info("Audit publishing is disabled")
+	return &noOpAuditPublisher{}
+}
+
+// EmitAuditEvent implements AuditPublisher
+func (s *AuditPublisherService) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+	//filter the required event to publish
+	if _, ok := s.cfg.EventByTypes[event.GetType()]; !ok {
+		log.Debugf("Skipping the audit event id:%v type: %v", event.GetID(), event.GetType())
+		return nil
+	}
+
+	log.Debugf("Publishing the audit event [ id %v  cluster: %v and type: %v ]", event.GetID(), event.GetClusterName(), event.GetType())
+	messageBody, err := json.Marshal(event)
+	if err != nil {
+		log.Errorf("Failed to serialize the audit event to json err: %v", err)
+		return trace.Wrap(err)
+	}
+
+	err = s.publisher.Publish(AuditMessage{
+		MessageBody: string(messageBody),
+	})
+
+	if err != nil {
+		log.Debugf("Failed to publish the audit event [ id %v  cluster: %v and type: %v ]", event.GetID(), event.GetClusterName(), event.GetType())
+		return err
+	}
+
+	log.Debugf("Published the audit event [ id %v  cluster: %v and type: %v ]", event.GetID(), event.GetClusterName(), event.GetType())
+	return nil
+}
+
+func getDefaultEventByTypes() map[string]string {
+	auditTypes := make(map[string]string)
+	auditTypes[events.SessionStartEvent] = events.SessionStartEvent
+	auditTypes[events.SessionEndEvent] = events.SessionEndEvent
+	auditTypes[events.AppSessionStartEvent] = events.AppSessionStartEvent
+	return auditTypes
+}
+
+type noOpAuditPublisher struct {
+}
+
+// EmitAuditEvent implements AuditPublisher
+func (*noOpAuditPublisher) EmitAuditEvent(context.Context, apievents.AuditEvent) error {
+	return nil
+}

--- a/lib/publisher/auditpublisher_test.go
+++ b/lib/publisher/auditpublisher_test.go
@@ -1,0 +1,37 @@
+package publisher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditPublisher(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	events := events.GenerateTestSession(events.SessionParams{PrintEvents: 0, ClusterName: "example.remote.idemeumlab.com"})
+	emitter := newAuditPublisher()
+
+	for _, event := range events {
+		err := emitter.EmitAuditEvent(ctx, event)
+		require.NoError(t, err)
+	}
+}
+
+func newAuditPublisher() AuditPublisher {
+	return &AuditPublisherService{
+		publisher: &noOpIdemeumAuditPublisher{},
+		cfg:       AuditPublisherConfig{},
+	}
+}
+
+type noOpIdemeumAuditPublisher struct {
+}
+
+func (*noOpIdemeumAuditPublisher) Publish(message AuditMessage) error {
+	return nil
+}

--- a/lib/publisher/sqsauditpublisher.go
+++ b/lib/publisher/sqsauditpublisher.go
@@ -1,0 +1,48 @@
+package publisher
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+)
+
+type sqsAuditMessagePublisherService struct {
+	sqsService *sqs.SQS
+	cfg        AuditPublisherConfig
+}
+
+func NewAuditMessagePublisherService(cfg AuditPublisherConfig) AuditMessagePublisher {
+	log.Info("Initializing the sqs audit publisher service")
+	session := session.Must(session.NewSession(&aws.Config{
+		Region: aws.String("us-west-2"),
+	}))
+
+	sqsService := sqs.New(session)
+	log.Info("Initialized the sqs audit publisher service")
+	return &sqsAuditMessagePublisherService{sqsService, cfg}
+}
+
+func (s *sqsAuditMessagePublisherService) Publish(audit AuditMessage) error {
+	queueUrlOutput, err := s.sqsService.GetQueueUrl(&sqs.GetQueueUrlInput{
+		QueueName: &s.cfg.SQSQueueName,
+	})
+	if err != nil {
+		log.Errorf("Failed to retrieve the qeueue url:%v err: %v", s.cfg.SQSQueueName, err)
+		return trace.Wrap(err)
+	}
+
+	output, err := s.sqsService.SendMessage(&sqs.SendMessageInput{
+		MessageBody: aws.String(audit.MessageBody),
+		QueueUrl:    queueUrlOutput.QueueUrl,
+	})
+
+	if err != nil {
+		log.Debugf("Failed to publish the message err :%v", err)
+		return trace.Wrap(err)
+	}
+
+	log.Debugf("Message published with messageId :%v", output.MessageId)
+	return nil
+}

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -20,7 +20,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/gravitational/teleport/lib/publisher"
 	"io"
 	"net"
 	"net/http"
@@ -31,6 +30,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/gravitational/teleport/lib/publisher"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
@@ -572,8 +573,11 @@ type AuthConfig struct {
 	// KeyStore configuration. Handles CA private keys which may be held in a HSM.
 	KeyStore keystore.Config
 
-	//
+	// AppPublisherConfig
 	AppPublisherConfig publisher.AppPublisherConfig
+
+	// AuditPublisherConfig config to publish the audit events
+	AuditPublisherConfig publisher.AuditPublisherConfig
 }
 
 // SSHConfig configures SSH server node role

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -26,7 +26,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/gravitational/teleport/lib/publisher"
 	"io"
 	"io/fs"
 	"net"
@@ -42,6 +41,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/gravitational/teleport/lib/publisher"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
@@ -1460,8 +1461,10 @@ func (process *TeleportProcess) initAuthService() error {
 		}
 	}
 
+	//Added audit publisher
+	auditPublisher := publisher.NewAuditPublisher(cfg.Auth.AuditPublisherConfig)
 	checkingEmitter, err := events.NewCheckingEmitter(events.CheckingEmitterConfig{
-		Inner:       events.NewMultiEmitter(events.NewLoggingEmitter(), emitter),
+		Inner:       events.NewMultiEmitter(events.NewLoggingEmitter(), emitter, auditPublisher),
 		Clock:       process.Clock,
 		ClusterName: cfg.Auth.ClusterName.GetClusterName(),
 	})


### PR DESCRIPTION
1. Added AuditPublisher which will publish the required events to
idemeum app management
2. Added configuration enable the audit publishing
3. Added AuditMessagePublisher which is responsible to publish the audit
message to destination
4. Added unit tests