### PR TITLE
IDEM-1948: Changed error message branding to idemeum

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1001,7 +1001,7 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 	}
 
 	if len(req.checker.GetAllowedResourceIDs()) > 0 && !modules.GetModules().Features().ResourceAccessRequests {
-		return nil, trace.AccessDenied("this Teleport cluster is not licensed for resource access requests, please contact the cluster administrator")
+		return nil, trace.AccessDenied("this idemeum cluster is not licensed for resource access requests, please contact the cluster administrator")
 	}
 
 	// Reject the cert request if there is a matching lock in force.
@@ -3071,7 +3071,7 @@ func (a *Server) CreateSessionTracker(ctx context.Context, tracker types.Session
 	for _, policySet := range tracker.GetHostPolicySets() {
 		if len(policySet.RequireSessionJoin) != 0 {
 			if !modules.GetModules().Features().ModeratedSessions {
-				return nil, trace.AccessDenied("this Teleport cluster is not licensed for moderated sessions, please contact the cluster administrator")
+				return nil, trace.AccessDenied("this idemeum cluster is not licensed for moderated sessions, please contact the cluster administrator")
 			}
 		}
 	}

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -115,7 +115,7 @@ func createBotUser(ctx context.Context, s *Server, botName string, resourceName 
 func (s *Server) createBot(ctx context.Context, req *proto.CreateBotRequest) (*proto.CreateBotResponse, error) {
 	if !modules.GetModules().Features().MachineID {
 		return nil, trace.AccessDenied(
-			"this Teleport cluster is not licensed for Machine ID, please contact the cluster administrator")
+			"this idemeum cluster is not licensed for Machine ID, please contact the cluster administrator")
 	}
 
 	if req.Name == "" {
@@ -461,7 +461,7 @@ func (s *Server) generateInitialBotCerts(ctx context.Context, username string, p
 
 	if !modules.GetModules().Features().MachineID {
 		return nil, trace.AccessDenied(
-			"this Teleport cluster is not licensed for Machine ID, please contact the cluster administrator")
+			"this idemeum cluster is not licensed for Machine ID, please contact the cluster administrator")
 	}
 
 	// Extract the user and role set for whom the certificate will be generated.

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -125,7 +125,7 @@ func getServerNames(req *proto.DatabaseCertRequest) []string {
 func (s *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequest) (*proto.DatabaseCSRResponse, error) {
 	if !modules.GetModules().Features().DB {
 		return nil, trace.AccessDenied(
-			"this Teleport cluster is not licensed for database access, please contact the cluster administrator")
+			"this idemeum cluster is not licensed for database access, please contact the cluster administrator")
 	}
 
 	log.Debugf("Signing database CSR for cluster %v.", req.ClusterName)
@@ -222,7 +222,7 @@ func (s *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequ
 func (s *Server) GenerateSnowflakeJWT(ctx context.Context, req *proto.SnowflakeJWTRequest) (*proto.SnowflakeJWTResponse, error) {
 	if !modules.GetModules().Features().DB {
 		return nil, trace.AccessDenied(
-			"this Teleport cluster is not licensed for database access, please contact the cluster administrator")
+			"this idemeum cluster is not licensed for database access, please contact the cluster administrator")
 	}
 
 	clusterName, err := s.GetClusterName()

--- a/lib/auth/desktop.go
+++ b/lib/auth/desktop.go
@@ -35,7 +35,7 @@ import (
 func (s *Server) GenerateWindowsDesktopCert(ctx context.Context, req *proto.WindowsDesktopCertRequest) (*proto.WindowsDesktopCertResponse, error) {
 	if !modules.GetModules().Features().Desktop {
 		return nil, trace.AccessDenied(
-			"this Teleport cluster is not licensed for desktop access, please contact the cluster administrator")
+			"this idemeum cluster is not licensed for desktop access, please contact the cluster administrator")
 	}
 	csr, err := tlsca.ParseCertificateRequestPEM(req.CSR)
 	if err != nil {

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -66,7 +66,7 @@ func (s *Server) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	ctx := context.TODO()
 	if !modules.GetModules().Features().Kubernetes {
 		return nil, trace.AccessDenied(
-			"this Teleport cluster is not licensed for Kubernetes, please contact the cluster administrator")
+			"this idemeum cluster is not licensed for Kubernetes, please contact the cluster administrator")
 	}
 	if err := req.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -42,7 +42,7 @@ import (
 func (s *Server) CreateAppSession(ctx context.Context, req types.CreateAppSessionRequest, user types.User, identity tlsca.Identity, checker services.AccessChecker) (types.WebSession, error) {
 	if !modules.GetModules().Features().App {
 		return nil, trace.AccessDenied(
-			"this Teleport cluster/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html is not licensed for application access, please contact the cluster administrator")
+			"this idemeum cluster is not licensed for application access, please contact the cluster administrator")
 	}
 
 	// Don't let the app session go longer than the identity expiration,
@@ -279,7 +279,7 @@ func (s *Server) CreateSnowflakeSession(ctx context.Context, req types.CreateSno
 ) (types.WebSession, error) {
 	if !modules.GetModules().Features().DB {
 		return nil, trace.AccessDenied(
-			"this Teleport cluster is not licensed for database access, please contact the cluster administrator")
+			"this idemeum cluster is not licensed for database access, please contact the cluster administrator")
 	}
 
 	// Don't let the app session go longer than the identity expiration,

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -107,7 +107,7 @@ func getKubeCreds(ctx context.Context, log logrus.FieldLogger, tpClusterName, ku
 		case KubeService:
 			return nil, trace.BadParameter("no Kubernetes credentials found; Kubernetes_service requires either a valid kubeconfig_file or to run inside of a Kubernetes pod")
 		case LegacyProxyService:
-			log.Debugf("Could not load Kubernetes credentials. This proxy will still handle Kubernetes requests for trusted teleport clusters or Kubernetes nodes in this teleport cluster")
+			log.Debugf("Could not load Kubernetes credentials. This proxy will still handle Kubernetes requests for trusted idemeum clusters or Kubernetes nodes in this idemeum cluster")
 		}
 		return map[string]*kubeCreds{}, nil
 	}
@@ -152,7 +152,7 @@ func extractKubeCreds(ctx context.Context, cluster string, clientCfg *rest.Confi
 	// For each loaded cluster, check impersonation permissions. This
 	// check only logs when permissions are not configured, but does not fail startup.
 	if err := checkPermissions(ctx, cluster, client.AuthorizationV1().SelfSubjectAccessReviews()); err != nil {
-		log.WithError(err).Warning("Failed to test the necessary Kubernetes permissions. The target Kubernetes cluster may be down or have misconfigured RBAC. This teleport instance will still handle Kubernetes requests towards this Kubernetes cluster.")
+		log.WithError(err).Warning("Failed to test the necessary Kubernetes permissions. The target Kubernetes cluster may be down or have misconfigured RBAC. This idemeum instance will still handle Kubernetes requests towards this Kubernetes cluster.")
 		if serviceType != KubeService && kubeconfigPath != "" {
 			// We used to recommend users to set a dummy kubeconfig on root
 			// proxies to get kubernetes support working for leaf clusters:

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -233,7 +233,7 @@ func CheckOrSetKubeCluster(ctx context.Context, p KubeServicesPresence, kubeClus
 	}
 	if kubeClusterName != "" {
 		if !apiutils.SliceContainsStr(kubeClusterNames, kubeClusterName) {
-			return "", trace.BadParameter("kubernetes cluster %q is not registered in this teleport cluster; you can list registered kubernetes clusters using 'tsh kube ls'", kubeClusterName)
+			return "", trace.BadParameter("kubernetes cluster %q is not registered in this idemeum cluster; you can list registered kubernetes clusters using 'tsh kube ls'", kubeClusterName)
 		}
 		return kubeClusterName, nil
 	}

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -370,7 +370,7 @@ func (s *localSite) skipDirectDial(params DialParams) (bool, error) {
 }
 
 func getTunnelErrorMessage(params DialParams, connStr string, err error) string {
-	errorMessageTemplate := `Teleport proxy failed to connect to %q agent %q over %s:
+	errorMessageTemplate := `Idemeum proxy failed to connect to %q agent %q over %s:
 
   %v
 

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -99,9 +99,9 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 	// Filter out cases where both listen_addr and tunnel are set or both are
 	// not set.
 	case useTunnel && !cfg.WindowsDesktop.ListenAddr.IsEmpty():
-		return trace.BadParameter("either set windows_desktop_service.listen_addr if this process can be reached from a teleport proxy or point teleport.auth_servers to a proxy to dial out, but don't set both")
+		return trace.BadParameter("either set windows_desktop_service.listen_addr if this process can be reached from a idemeum proxy or point teleport.auth_servers to a proxy to dial out, but don't set both")
 	case !useTunnel && cfg.WindowsDesktop.ListenAddr.IsEmpty():
-		return trace.BadParameter("set windows_desktop_service.listen_addr if this process can be reached from a teleport proxy or point teleport.auth_servers to a proxy to dial out")
+		return trace.BadParameter("set windows_desktop_service.listen_addr if this process can be reached from a idemeum proxy or point teleport.auth_servers to a proxy to dial out")
 
 	// Start a local listener and let proxies dial in.
 	case !useTunnel && !cfg.WindowsDesktop.ListenAddr.IsEmpty():

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -112,7 +112,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 	// Filter out cases where both listen_addr and tunnel are set or both are
 	// not set.
 	case conn.UseTunnel() && !cfg.Kube.ListenAddr.IsEmpty():
-		return trace.BadParameter("either set kubernetes_service.listen_addr if this process can be reached from a teleport proxy or point teleport.auth_servers to a proxy to dial out, but don't set both")
+		return trace.BadParameter("either set kubernetes_service.listen_addr if this process can be reached from a idemeum proxy or point teleport.auth_servers to a proxy to dial out, but don't set both")
 	case !conn.UseTunnel() && cfg.Kube.ListenAddr.IsEmpty():
 		// TODO(awly): if this process runs auth, proxy and kubernetes
 		// services, the proxy should be able to route requests to this
@@ -122,7 +122,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 		//
 		// For now, as a lazy shortcut, kuberentes_service.listen_addr is
 		// always required when running in the same process with a proxy.
-		return trace.BadParameter("set kubernetes_service.listen_addr if this process can be reached from a teleport proxy or point teleport.auth_servers to a proxy to dial out")
+		return trace.BadParameter("set kubernetes_service.listen_addr if this process can be reached from a idemeum proxy or point teleport.auth_servers to a proxy to dial out")
 
 	// Start a local listener and let proxies dial in.
 	case !conn.UseTunnel() && !cfg.Kube.ListenAddr.IsEmpty():

--- a/lib/web/app/redirect.go
+++ b/lib/web/app/redirect.go
@@ -48,7 +48,7 @@ const js = `
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Teleport Redirection Service</title>
+    <title>Idemeum Redirection Service</title>
     <script nonce="%v">
       (function() {
         var url = new URL(window.location);


### PR DESCRIPTION
- Changed the error message to show as idemeum rather than
teleport keyword to avoid confusion for end user