### PR TITLE
IDEM-1976: Build and publish binaries to s3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,8 +372,8 @@ release-unix: clean full
 		build.assets/install\
 		idemeum/
 	mkdir idemeum/systemd	
-	cp -f examples/systemd/teleport.service idemeum/systemd/idemeum.service
-
+	cp -f examples/systemd/idemeum.service idemeum/systemd/idemeum.service
+	cp -f examples/systemd/README.md idemeum/systemd/README.md
 	echo $(GITTAG) > idemeum/VERSION
 	tar $(TAR_FLAGS) -c idemeum | gzip -n > $(RELEASE).tar.gz
 	rm -rf idemeum
@@ -963,7 +963,7 @@ install: build
 	@echo "\n** Make sure to run 'make install' as root! **\n"
 	cp -f $(BUILDDIR)/tctl      $(BINDIR)/
 	cp -f $(BUILDDIR)/tsh       $(BINDIR)/
-	cp -f $(BUILDDIR)/teleport  $(BINDIR)/
+	cp -f $(BUILDDIR)/idemeum  $(BINDIR)/
 	mkdir -p $(DATADIR)
 
 

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -80,7 +80,6 @@ RUN apt-get update -y --fix-missing && \
         libpam-dev \
         libsqlite3-0 \
         libssl-dev \
-        libudev-dev \
         llvm-10 \
         locales \
         mingw-w64 \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -84,7 +84,7 @@ export
 build: buildbox
 	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX) \
 		make -C $(SRCDIR) ADDFLAGS='$(ADDFLAGS)' release
-
+	
 #
 # Build 'teleport' release inside a docker container
 #

--- a/examples/systemd/README.md
+++ b/examples/systemd/README.md
@@ -1,24 +1,24 @@
 # Systemd Service
 
-Sample configuration of `systemd` service file for Teleport
+Sample configuration of `systemd` service file for Idemeum
 To use it:
 
 ```bash
-sudo cp teleport.service /etc/systemd/system/teleport.service
+sudo cp idemeum.service /etc/systemd/system/idemeum.service
 sudo systemctl daemon-reload
-sudo systemctl enable teleport
-sudo systemctl start teleport
+sudo systemctl enable idemeum
+sudo systemctl start idemeum
 ```
 
 To check on Teleport daemon status:
 
 ```bash
-systemctl status teleport
+systemctl status idemeum
 ```
 
-To take a look at Teleport system log:
+To take a look at idemeum system log:
 
 ```bash
-journalctl -fu teleport
+journalctl -fu idemeum
 ```
 

--- a/examples/systemd/idemeum.service
+++ b/examples/systemd/idemeum.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Idemeum SSH Service
+After=network.target
+
+[Service]
+Type=simple
+Restart=on-failure
+EnvironmentFile=-/etc/default/idemeum
+ExecStart=/usr/local/bin/idemeum start --pid-file=/run/idemeum.pid
+ExecReload=/bin/kill -HUP $MAINPID
+PIDFile=/run/idemeum.pid
+LimitNOFILE=8192
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/systemd/teleport.service
+++ b/examples/systemd/teleport.service
@@ -1,14 +1,14 @@
 [Unit]
-Description=Idemeum SSH Service
+Description=Teleport SSH Service
 After=network.target
 
 [Service]
 Type=simple
 Restart=on-failure
-EnvironmentFile=-/etc/default/idemeum
-ExecStart=/usr/local/bin/idemeum start --pid-file=/run/idemeum.pid
+EnvironmentFile=-/etc/default/teleport
+ExecStart=/usr/local/bin/teleport start --pid-file=/run/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
-PIDFile=/run/idemeum.pid
+PIDFile=/run/teleport.pid
 LimitNOFILE=8192
 
 [Install]

--- a/support/cloud-build.sh
+++ b/support/cloud-build.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+help()
+{
+   echo ""
+   echo "Usage: $0 -r <aws region> -p <aws credential profile> -s <s3 bucket name> -b [publish|build|upload] "
+   exit 1 # Exit script after printing help
+}
+
+s3bucketName=
+#Upload file to s3
+function upload() {
+   releaseFile="$(basename -- $1)"
+   echo "Copying the file to s3://$s3bucketName/$releaseFile"
+   aws --region $region --profile $profile s3 cp $1 s3://$s3bucketName/$releaseFile
+}
+
+function cleanup() {
+   echo "Deleting old binaries"
+   rm -rf "idemeum-remote-access-*"
+}
+
+while getopts ":p:r:a:b:s:" opt
+do
+   case "$opt" in
+      p ) profile="$OPTARG" ;;
+      r ) region="$OPTARG" ;;
+      b ) buildOption="$OPTARG" ;;
+      s ) s3bucketName="$OPTARG" ;;
+      #? ) help ;; # Print help in case parameter is non-existent
+   esac
+done
+
+echo "Parameters: $profile $region $buildOption"
+# Print helpFunction in case parameters are empty
+if [ -z "$profile" ] || [ -z "$buildOption" ] || [ -z "$region" ]; then
+   echo "Missing required parameters";
+   help
+fi
+
+if [[ "$buildOption" == "publish" ]]; then
+   cleanup
+   echo "Build and publish the release binary aws s3"
+   #Command to build for current platform 
+   make release -C build.assets build-binaries
+   for file in $(find . -name "idemeum-remote-access-*" -type f ) ; do 
+      upload "$file"
+   done 
+elif [[ "$buildOption" == "upload" ]]; then
+   cleanup
+   echo "Uploading the release binary aws s3"
+   #Lookup binary and upload
+   for file in $(find . -name "idemeum-remote-access-*" -type f ) ; do 
+      upload "$file"
+   done 
+else
+   echo "Building the release binary"
+   cleanup
+   make release -C build.assets build-binaries
+fi

--- a/support/prod-cloud-build.sh
+++ b/support/prod-cloud-build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+build=$1
+echo "Build : $build"
+sh support/cloud-build.sh -s idemeum-prod-public -r us-west-2 -p prod -b $build

--- a/support/stg-cloud-build.sh
+++ b/support/stg-cloud-build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+build=$1
+echo "Build : $build"
+sh support/cloud-build.sh -s idemeum-staging-public -r us-west-2 -p stg -b $build


### PR DESCRIPTION
- Fixed the build problem using the ubuntu
by removing the libudev-dev dependency which has been
removed in the teleport repo as well.
- Build and publish binaries to s3