### PR TITLE
IDEM-1999: Publish the event when ssh node is added to auth server

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -105,7 +105,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		cfg.Trust = local.NewCAService(cfg.Backend)
 	}
 	if cfg.Presence == nil {
-		cfg.Presence = local.NewPresenceService(cfg.Backend)
+		cfg.Presence = local.NewPresenceServiceV2(cfg.Backend, cfg.AppPublisher)
 	}
 	if cfg.Provisioner == nil {
 		cfg.Provisioner = local.NewProvisioningService(cfg.Backend)
@@ -211,7 +211,6 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		keyStore:     keyStore,
 		getClaimsFun: getClaims,
 		inventory:    inventory.NewController(cfg.Presence),
-		tenantUrl:    cfg.TenantUrl,
 		AppPublisher: cfg.AppPublisher,
 	}
 	for _, o := range opts {
@@ -383,14 +382,8 @@ type Server struct {
 
 	inventory *inventory.Controller
 
-	//Tenant Url
-	tenantUrl string
 	//App Publisher
 	AppPublisher publisher.AppPublisher
-}
-
-func (a *Server) GetTenantUrl() string {
-	return a.tenantUrl
 }
 
 func (a *Server) CloseContext() context.Context {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -777,7 +777,7 @@ func (a *ServerWithRoles) PingInventory(ctx context.Context, req proto.Inventory
 }
 
 func (a *ServerWithRoles) UpsertNode(ctx context.Context, s types.Server) (*types.KeepAlive, error) {
-	log.Infof("Add or update server :%v", s.GetName())
+	log.Infof("Upserting the node :%v with addr :%v ", s.GetName(), s.GetHostname())
 	if err := a.action(s.GetNamespace(), types.KindNode, types.VerbCreate, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -4927,6 +4927,5 @@ func verbsToReplaceResourceWithOrigin(stored types.ResourceWithOrigin) []string 
 func publishAppChanges(server *Server, appType publisher.RemoteAppType) {
 	server.AppPublisher.Publish(publisher.AppChangeEvent{
 		AppType: appType,
-		Tenant:  server.GetTenantUrl(),
 	})
 }

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"github.com/gravitational/teleport/lib/publisher"
 	"net"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/gravitational/teleport/lib/publisher"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
@@ -244,8 +245,8 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 		Streamer:               cfg.Streamer,
 		SkipPeriodicOperations: true,
 		Emitter:                emitter,
-		AppPublisher:           publisher.NewAppPublisher(publisher.AppPublisherConfig{}),
-		TenantUrl:              "https://test.idemeum.com",
+		AppPublisher: publisher.NewAppPublisher(publisher.AppPublisherConfig{Enabled: false,
+			TenantUrl: "https://test.idemeum.com"}),
 	}, WithClock(cfg.Clock))
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -21,9 +21,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/gravitational/teleport/lib/publisher"
 	"strings"
 	"time"
+
+	"github.com/gravitational/teleport/lib/publisher"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
@@ -171,9 +172,6 @@ type InitConfig struct {
 	WindowsDesktops services.WindowsDesktops
 
 	SessionTrackerService services.SessionTrackerService
-
-	//Tenant url
-	TenantUrl string
 
 	//App Publisher
 	AppPublisher publisher.AppPublisher

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -709,14 +709,23 @@ func applyKeyStoreConfig(fc *FileConfig, cfg *service.Config) error {
 	return nil
 }
 
-// applyAppPublisherConfig applies file configuration for the "proxy_service" section.
+// applyAppPublisherConfig applies file configuration for the "auth-service" section.
 func applyAppPublisherConfig(fc *FileConfig, cfg *service.Config) error {
+
 	if fc.Auth.AppPublisherConfig == nil {
 		cfg.Auth.AppPublisherConfig.SQSQueueName = ""
 		return nil
 	}
 
+	enabled, _ := apiutils.ParseBool(fc.Auth.AppPublisherConfig.Enabled)
+	cfg.Auth.AppPublisherConfig.Enabled = enabled
+
 	cfg.Auth.AppPublisherConfig.SQSQueueName = fc.Auth.AppPublisherConfig.SQSQueueName
+
+	if fc.TenantUrl != "" {
+		cfg.Auth.AppPublisherConfig.TenantUrl = fc.TenantUrl
+	}
+
 	return nil
 }
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -721,6 +721,7 @@ type Auth struct {
 }
 
 type AppPublisherConfig struct {
+	Enabled      string `yaml:"enabled,omitempty"`
 	SQSQueueName string `yaml:"sqs_queue_name,omitempty"`
 }
 

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -267,6 +267,8 @@ func (c *Controller) handleSSHServerHB(handle *upstreamHandle, sshServer *types.
 
 	sshServer.SetExpiry(time.Now().Add(c.serverTTL).UTC())
 
+	log.Infof("Upserting the node :%v with addr :%v ", sshServer.GetName(), sshServer.GetHostname())
+
 	lease, err := c.auth.UpsertNode(c.closeContext, sshServer)
 	if err == nil {
 		c.testEvent(sshUpsertOk)

--- a/lib/publisher/sqsapppublisher.go
+++ b/lib/publisher/sqsapppublisher.go
@@ -2,6 +2,7 @@ package publisher
 
 import (
 	"encoding/json"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
@@ -33,7 +34,6 @@ func NewSQSAppPublisherService(queueName string) AppPublisher {
 }
 
 func (s *sqsAppPublisherService) Publish(event AppChangeEvent) error {
-	log.Infof("Publishing event for tenant: %v and app type: %v", event.Tenant, event.AppType)
 	queueUrlOutput, err := s.sqsService.GetQueueUrl(&sqs.GetQueueUrlInput{
 		QueueName: &s.config.QueueName,
 	})

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1512,7 +1512,6 @@ func (process *TeleportProcess) initAuthService() error {
 		KeyStoreConfig:          cfg.Auth.KeyStore,
 		Emitter:                 checkingEmitter,
 		Streamer:                events.NewReportingStreamer(checkingStreamer, process.Config.UploadEventsC),
-		TenantUrl:               cfg.TenantUrl,
 		AppPublisher:            publisher.NewAppPublisher(cfg.Auth.AppPublisherConfig),
 	})
 	if err != nil {

--- a/lib/srv/heartbeat.go
+++ b/lib/srv/heartbeat.go
@@ -430,6 +430,7 @@ func (h *Heartbeat) announce() error {
 			if !ok {
 				return trace.BadParameter("expected services.Server, got %#v", h.current)
 			}
+			log.Infof("Upserting the node :%v with addr :%v ", node.GetName(), node.GetHostname())
 			keepAlive, err := h.Announcer.UpsertNode(h.cancelCtx, node)
 			if err != nil {
 				return trace.Wrap(err)

--- a/lib/srv/heartbeatv2.go
+++ b/lib/srv/heartbeatv2.go
@@ -417,6 +417,7 @@ func (h *sshServerHeartbeatV2) FallbackAnnounce(ctx context.Context) (ok bool) {
 		return false
 	}
 	server := h.getServer()
+	log.Infof("Upserting the node :%v with addr :%v ", server.GetName(), server.GetHostname())
 	_, err := h.announcer.UpsertNode(ctx, server)
 	if err != nil {
 		log.Warnf("Failed to perform fallback heartbeat for ssh server: %v", err)


### PR DESCRIPTION
- Teleport announce proxy, ssh nodes to auth server using the heartbeat announcemechanism.
- Changed the presence service code to publish the event only if the node is inserted in the auth service storage. Every service maintains its own local DB where the record is inserted, its done carefully not to publish events for those updates.
- Added logs to debug issue in case event is published or not