### PR TITLE
IDEM-2012: Send notification when the resource is deleted in db

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -105,7 +105,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		cfg.Trust = local.NewCAService(cfg.Backend)
 	}
 	if cfg.Presence == nil {
-		cfg.Presence = local.NewPresenceServiceV2(cfg.Backend, cfg.AppPublisher)
+		cfg.Presence = local.NewIdemeumPresenceService(cfg.Backend, cfg.AppPublisher)
 	}
 	if cfg.Provisioner == nil {
 		cfg.Provisioner = local.NewProvisioningService(cfg.Backend)
@@ -208,10 +208,11 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 			WindowsDesktops:       cfg.WindowsDesktops,
 			SessionTrackerService: cfg.SessionTrackerService,
 		},
-		keyStore:     keyStore,
-		getClaimsFun: getClaims,
-		inventory:    inventory.NewController(cfg.Presence),
-		AppPublisher: cfg.AppPublisher,
+		keyStore:               keyStore,
+		getClaimsFun:           getClaims,
+		inventory:              inventory.NewController(cfg.Presence),
+		AppPublisher:           cfg.AppPublisher,
+		RemoteAccessAppWatcher: publisher.NewRemoteAccessAppWatcher(context.Background(), cfg.Events, cfg.AppPublisher),
 	}
 	for _, o := range opts {
 		o(&as)
@@ -382,8 +383,8 @@ type Server struct {
 
 	inventory *inventory.Controller
 
-	//App Publisher
-	AppPublisher publisher.AppPublisher
+	AppPublisher           publisher.AppPublisher
+	RemoteAccessAppWatcher *publisher.RemoteAccessAppWatcher
 }
 
 func (a *Server) CloseContext() context.Context {

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -266,9 +266,6 @@ func (c *Controller) handleSSHServerHB(handle *upstreamHandle, sshServer *types.
 	}
 
 	sshServer.SetExpiry(time.Now().Add(c.serverTTL).UTC())
-
-	log.Infof("Upserting the node :%v with addr :%v ", sshServer.GetName(), sshServer.GetHostname())
-
 	lease, err := c.auth.UpsertNode(c.closeContext, sshServer)
 	if err == nil {
 		c.testEvent(sshUpsertOk)

--- a/lib/publisher/remoteaccessappwatcher.go
+++ b/lib/publisher/remoteaccessappwatcher.go
@@ -1,0 +1,106 @@
+package publisher
+
+import (
+	"context"
+
+	"github.com/cloudflare/cfssl/log"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+)
+
+type RemoteAccessAppWatcher struct {
+	events    types.Events
+	publisher AppPublisher
+	cfg       remoteAccessAppWatcherConfig
+}
+
+type remoteAccessAppWatcherConfig struct {
+	Watches []types.WatchKind
+}
+
+func NewIdemeumRemoteResourceWatcher(ctx context.Context, events types.Events, appPublisher AppPublisher) *RemoteAccessAppWatcher {
+	appWatcher := &RemoteAccessAppWatcher{
+		events:    events,
+		publisher: appPublisher,
+		cfg:       defaultAppWatcherConfig(),
+	}
+	go appWatcher.watch(ctx)
+	return appWatcher
+}
+
+// defaultAppWatcherConfig default app watcher config
+func defaultAppWatcherConfig() remoteAccessAppWatcherConfig {
+	Watches := []types.WatchKind{
+		{Kind: types.KindNode},
+		{Kind: types.KindAppServer},
+		{Kind: types.KindApp},
+	}
+	return remoteAccessAppWatcherConfig{Watches: Watches}
+}
+
+func (c *RemoteAccessAppWatcher) watch(ctx context.Context) error {
+	log.Info("Watching the app changes")
+	watcher, err := c.events.NewWatcher(ctx, types.Watch{
+		Name:  "remote-access-apps",
+		Kinds: c.cfg.Watches,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer watcher.Close()
+	for {
+		select {
+		case event := <-watcher.Events():
+			// OpInit is a special case omitted by the Watcher when the
+			// connection succeeds.
+			if event.Type == types.OpInit {
+				log.Infof("Started watching for apps changes")
+				continue
+			}
+			c.processEvent(event)
+		case <-watcher.Done():
+			if err := watcher.Error(); err != nil {
+				return trace.Wrap(err)
+			}
+			return nil
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (c *RemoteAccessAppWatcher) processEvent(event types.Event) error {
+
+	if !canProcessEventType(event) {
+		log.Debugf("skipping the event type: %v for resource type: %v and name :%v", event.Type, event.Resource.GetKind(), event.Resource.GetName())
+		return nil
+	}
+
+	log.Infof("remote access app watcher processing the event type: %v for resource type: %v and name :%v ", event.Type, event.Resource.GetKind(), event.Resource.GetName())
+	appType := getRemoteAppType(event.Resource)
+
+	if appType == Invalid {
+		log.Debugf("skipping remote access app watcher processing for app type: %v", appType)
+		return nil
+	}
+
+	return c.publisher.Publish(AppChangeEvent{
+		AppType: appType,
+	})
+}
+
+func canProcessEventType(event types.Event) bool {
+	// we are only processing the delete event from the database
+	// insert to database are already processed in the place of record insertion
+	return event.Type == types.OpDelete
+}
+
+func getRemoteAppType(resource types.Resource) RemoteAppType {
+	switch resource.GetKind() {
+	case types.KindNode:
+		return Server
+	case types.KindAppServer, types.KindApp:
+		return Webapp
+	}
+	return Invalid
+}

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -52,10 +52,10 @@ type backendItemToResourceFunc func(item backend.Item) (types.ResourceWithLabels
 
 // NewPresenceService returns new presence service instance
 func NewPresenceService(b backend.Backend) *PresenceService {
-	return NewPresenceServiceV2(b, nil)
+	return NewIdemeumPresenceService(b, nil)
 }
 
-func NewPresenceServiceV2(b backend.Backend, publisher publisher.AppPublisher) *PresenceService {
+func NewIdemeumPresenceService(b backend.Backend, publisher publisher.AppPublisher) *PresenceService {
 	return &PresenceService{
 		log:       logrus.WithFields(logrus.Fields{trace.Component: "Presence"}),
 		jitter:    utils.NewJitter(),


### PR DESCRIPTION
- Teleport monitors the database changes using the Events framework
- Plugged-in the remote access watcher to monitor the deleted resources to send the notification to app management
- Added default delay of 30s for publishing message to app management as the teleport in-memory cache is eventually consistent it takes time to reflect the changes