### PR TITLE
IDEM-2034: Use presets to configure the remote access server

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -447,6 +447,9 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 		cfg.TenantUrl = fc.TenantUrl
 	}
 
+	IdemeumPresetsEnabled, _ := apiutils.ParseBool(fc.IdemeumPresetsEnabled)
+	cfg.IdemeumPresetsEnabled = IdemeumPresetsEnabled
+
 	return nil
 }
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -87,6 +87,8 @@ type FileConfig struct {
 
 	//TenantUrl configures the tenant url for which the cluster is serving.
 	TenantUrl string `yaml:"tenant_url,omitempty"`
+
+	IdemeumPresetsEnabled string `yaml:"idemeum_presets_enabled,omitempty"`
 }
 
 // ReadFromFile reads Teleport configuration from a file. Currently only YAML

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -271,7 +271,8 @@ type Config struct {
 	CircuitBreakerConfig breaker.Config
 
 	//Tenant Url
-	TenantUrl string
+	TenantUrl             string
+	IdemeumPresetsEnabled bool
 }
 
 // ApplyToken assigns a given token to all internal services but only if token

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1513,6 +1513,8 @@ func (process *TeleportProcess) initAuthService() error {
 		Emitter:                 checkingEmitter,
 		Streamer:                events.NewReportingStreamer(checkingStreamer, process.Config.UploadEventsC),
 		AppPublisher:            publisher.NewAppPublisher(cfg.Auth.AppPublisherConfig),
+		TenantUrl:               cfg.TenantUrl,
+		IdemeumPresetsEnabled:   cfg.IdemeumPresetsEnabled,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/services/idemeumpresets.go
+++ b/lib/services/idemeumpresets.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"strings"
+
+	"github.com/gravitational/teleport/api/constants"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+)
+
+func NewIdemeumAdminRole() types.Role {
+	return idemeumRole("ADMIN", true)
+}
+
+func NewIdemeumUserRole() types.Role {
+	return idemeumRole("USER", true)
+}
+
+func NewIdemeumSamlConnector(idemeumTenantUrl string) (types.SAMLConnector, error) {
+	acsUrl, err := getACSUrl(idemeumTenantUrl)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	issuerUrl := idemeumTenantUrl + "/api/saml/metadata"
+	ssoUrl := idemeumTenantUrl + "/saml/signon"
+	return &types.SAMLConnectorV2{
+		Kind:    types.KindSAMLConnector,
+		Version: types.V2,
+		Metadata: types.Metadata{
+			Name: "idemeum-saml",
+		},
+		Spec: types.SAMLConnectorSpecV2{
+			AssertionConsumerService: acsUrl,
+			AttributesToRoles: []types.AttributeMapping{
+				{
+					Name:  "roles",
+					Value: "USER",
+					Roles: []string{"USER"},
+				},
+				{
+					Name:  "roles",
+					Value: "ADMIN",
+					Roles: []string{"ADMIN"},
+				},
+			},
+			Audience:              acsUrl,
+			Display:               "Idemeum",
+			EntityDescriptorURL:   issuerUrl,
+			Issuer:                issuerUrl,
+			ServiceProviderIssuer: acsUrl,
+			SSO:                   ssoUrl,
+		},
+	}, nil
+}
+
+func idemeumRole(roleName string, admin bool) types.Role {
+	role := &types.RoleV5{
+		Kind:    types.KindRole,
+		Version: types.V5,
+		Metadata: types.Metadata{
+			Name:        roleName,
+			Namespace:   apidefaults.Namespace,
+			Description: "Idemeum remote access resources",
+		},
+		Spec: types.RoleSpecV5{
+			Options: types.RoleOptions{
+				CertificateFormat: constants.CertificateFormatStandard,
+				MaxSessionTTL:     types.NewDuration(apidefaults.MaxCertDuration),
+				PortForwarding:    types.NewBoolOption(true),
+				ForwardAgent:      types.NewBool(true),
+				BPF:               apidefaults.EnhancedEvents(),
+				RecordSession:     &types.RecordSession{Desktop: types.NewBoolOption(true)},
+			},
+			Allow: types.RoleConditions{
+				Namespaces: []string{apidefaults.Namespace},
+				NodeLabels: types.Labels{"idemeum_app_id": []string{"{{external.node_ids}}"}},
+				AppLabels:  types.Labels{"idemeum_app_id": []string{"{{external.app_ids}}"}},
+				Rules:      getRoleRules(admin),
+			},
+		},
+	}
+	role.SetLogins(types.Allow, []string{"{{external.node_users}}"})
+	return role
+}
+
+func getRoleRules(admin bool) []types.Rule {
+	if admin {
+		return []types.Rule{
+			{
+				Resources: []string{types.KindSession},
+				Verbs:     []string{types.VerbRead, types.VerbList},
+				Where:     "contains(session.participants, user.metadata.name)",
+			},
+		}
+	}
+	return []types.Rule{
+		{
+			Resources: []string{types.KindSession},
+			Verbs:     []string{types.VerbRead, types.VerbList},
+		},
+	}
+}
+
+func getACSUrl(tenantUrl string) (string, error) {
+	remoteAccessUrl := ""
+	if strings.Contains(tenantUrl, ".idemeum.com") {
+		remoteAccessUrl = strings.ReplaceAll(tenantUrl, ".idemeum.com", ".remote.idemeum.com")
+	} else if strings.Contains(tenantUrl, ".idemeumlab.com") {
+		remoteAccessUrl = strings.ReplaceAll(tenantUrl, ".idemeumlab.com", ".remote.idemeumlab.com")
+	} else {
+		return "", trace.BadParameter("invalid idemeum tenant url")
+	}
+	return remoteAccessUrl + "/v1/webapi/saml/acs", nil
+}

--- a/lib/services/idemeumpresets_test.go
+++ b/lib/services/idemeumpresets_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdemeumSamlConnector(t *testing.T) {
+
+	connector, err := NewIdemeumSamlConnector("https://example.idemeum.com")
+
+	require.Nil(t, err)
+	require.Empty(t, connector.GetSigningKeyPair())
+
+	require.Equal(t, connector.GetAssertionConsumerService(), "https://example.remote.idemeum.com/v1/webapi/saml/acs")
+	require.Equal(t, connector.GetIssuer(), "https://example.idemeum.com/api/saml/metadata")
+	require.Equal(t, connector.GetEntityDescriptorURL(), "https://example.idemeum.com/api/saml/metadata")
+	require.Equal(t, connector.GetServiceProviderIssuer(), "https://example.remote.idemeum.com/v1/webapi/saml/acs")
+	require.Equal(t, connector.GetSSO(), "https://example.idemeum.com/saml/signon")
+}


### PR DESCRIPTION
- added presets for roles admin and user
- added presets for saml connector configuration based on tenantUrl
- added knob to enable/dsiable the applying the idemeum presets during startup