### PR TITLE
IDEM-2124: Ignore some teleport resources so we won't have tests failing in Vanta

### DIFF
--- a/examples/aws/cloudformation/idemeum.yaml
+++ b/examples/aws/cloudformation/idemeum.yaml
@@ -230,6 +230,8 @@ Resources:
           Value: !Join [" ", ["Remote Access ", !Ref TenantName, " - AuthEc2Instance"]]
         - Key: VantaOwner
           Value: goprean@idemeum.com
+        - Key: VantaNoAlert
+          Value: 'Need to have this with public port available so the reverse proxy will work. Also no alarm will be created for CPU'
 
   AuthLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
@@ -600,6 +602,8 @@ Resources:
           Value: !Join [" ", ["Remote Access ", !Ref TenantName, " - ProxyEc2Instance"]]
         - Key: VantaOwner
           Value: goprean@idemeum.com
+        - Key: VantaNoAlert
+          Value: 'Need to have this with public port available so the reverse proxy will work. Also no alarm will be created for CPU'
 
   ProxyLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
@@ -1031,6 +1035,8 @@ Resources:
           Value: !Join [" ", ["Remote Access ", !Ref TenantName, " -  Main Table"]]
         - Key: VantaOwner
           Value: goprean@idemeum.com
+        - Key: VantaNoAlert
+          Value: 'Will not create read/write monitoring alarms for this table.'
 
 
   # LocksTable is a dynamodb table that is
@@ -1064,6 +1070,8 @@ Resources:
           Value: !Join [" ", ["Remote Access ", !Ref TenantName, " -  Locks Table"]]
         - Key: VantaOwner
           Value: goprean@idemeum.com
+        - Key: VantaNoAlert
+          Value: 'Will not create read/write monitoring alarms for this table.'
 
   EventsTable:
     Type: AWS::DynamoDB::Table
@@ -1110,6 +1118,8 @@ Resources:
           Value: !Join [" ", ["Remote Access ", !Ref TenantName, " - Events Table"]]
         - Key: VantaOwner
           Value: goprean@idemeum.com
+        - Key: VantaNoAlert
+          Value: 'Will not create read/write monitoring alarms for this table.'          
   # Bucket is used to publish letsencrypt certs
   # and store recorded SSH sessions
   Bucket:


### PR DESCRIPTION
This is a temporary fix, in my opinion.

Problem:
Every time we create the teleport stack for a tenant, the resources that are created will be monitored by Vanta. Then it will complain about the following:

EC2 instances (proxy & auth) does not have the server CPU monitored
EC2 instance exposes public ports
DynamoDb Tables for Main, Events & Locks does not have the Read & Write capacity monitored.
Discussed with Vanta and there is no way to pull in the resources and disable only certain tests (for example the public ports). So we will use the VantaNoAlert to not create the alarms for this resource.

In my opinion this is a temporary fix. We should be creating the alarms for Read/Write capacity for the tables and server CPU for the EC2 instances even when the customer is in trial mode.
Then we should be implementing the tenant cleanup and we should delete the teleport stack which will clear all the resources. It is true that we will incur some costs while the tenant is in trial.

We still have to solve the problem of what happens when the tenant goes from trial to production. In that case we do want to monitor the EC2 and Dynamo DB tables. We still have to ignore the public ports since that is a requirement for the teleport proxy to work.