### PR TITLE
IDEM-2165: only proxy services should have access to the auth service

### DIFF
--- a/examples/aws/cloudformation/idemeum.yaml
+++ b/examples/aws/cloudformation/idemeum.yaml
@@ -118,10 +118,10 @@ Resources:
       VpcId: '{{resolve:ssm:/Services/VPC/Id}}'
       SecurityGroupIngress:
         - IpProtocol: tcp
-          Description: Everyone is allowed to use auth service API.
+          Description: Only proxy service should be able to access the auth service.
           FromPort: 3025
           ToPort: 3025
-          CidrIp: 0.0.0.0/0
+          SourceSecurityGroupId: !Ref ProxySecurityGroup
       SecurityGroupEgress:
         - IpProtocol: "-1"
           Description: Egress is allowed anywhere


### PR DESCRIPTION
Aș per the teleport documentation, only the proxy service should be available to the outside world.
Make the auth service only available from the proxy service nodes of the tenant teleport cluster.