### PR TITLE
IDEM-2264: Rename the DN for windows to idemeum

### DIFF
--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -1200,7 +1200,7 @@ func (s *WindowsService) crlDN() string {
 // crlContainerDN generates the LDAP distinguished name (DN) of the container
 // where the certificate revocation list is published
 func (s *WindowsService) crlContainerDN() string {
-	return "CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration," + s.cfg.LDAPConfig.domainDN()
+	return "CN=Idemeum,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration," + s.cfg.LDAPConfig.domainDN()
 }
 
 // generateCredentials generates a private key / certificate pair for the given

--- a/lib/srv/desktop/windows_server_test.go
+++ b/lib/srv/desktop/windows_server_test.go
@@ -97,11 +97,11 @@ func TestCRLDN(t *testing.T) {
 	}{
 		{
 			clusterName: "test",
-			crlDN:       "CN=test,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
+			crlDN:       "CN=test,CN=Idemeum,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
 		},
 		{
 			clusterName: "cluster.goteleport.com",
-			crlDN:       "CN=cluster.goteleport.com,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
+			crlDN:       "CN=cluster.goteleport.com,CN=Idemeum,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
 		},
 	} {
 		t.Run(test.clusterName, func(t *testing.T) {
@@ -172,7 +172,7 @@ func TestGenerateCredentials(t *testing.T) {
 
 	require.Equal(t, user, cert.Subject.CommonName)
 	require.Contains(t, cert.CRLDistributionPoints,
-		`ldap:///CN=test,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=example,DC=com?certificateRevocationList?base?objectClass=cRLDistributionPoint`)
+		`ldap:///CN=test,CN=Idemeum,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=example,DC=com?certificateRevocationList?base?objectClass=cRLDistributionPoint`)
 
 	foundKeyUsage := false
 	foundAltName := false


### PR DESCRIPTION
For windowsdesktop service the user DN are setup using the CN=Teleport, CN=.. we would like to change the branding to CN=Idemeum,CN=..