### PR TITLE
IDEM-2261: Allow LDAP pem cert as inline configuration

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1616,6 +1616,9 @@ type LDAPConfig struct {
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`
 	// DEREncodedCAFile is the filepath to an optional DER encoded CA cert to be used for verification (if InsecureSkipVerify is set to false).
 	DEREncodedCAFile string `yaml:"der_ca_file,omitempty"`
+
+	// PEMEncodedCACert is an optional PEM encoded CA cert to be used for verification (if InsecureSkipVerify is set to false).
+	PEMEncodedCACert string `yaml:"ldap_ca_cert,omitempty"`
 }
 
 // TracingService contains configuration for the tracing_service.


### PR DESCRIPTION
-Enhanced the windows ldap config to support the ldap ca cert as pem format i.e. example
ldap:
 ...
 # PEM encoded LDAP CA certificate.
 ldap_ca_cert: |
  -----BEGIN CERTIFICATE-----
  *certificate data*
  -----END CERTIFICATE-----