### PR TITLE
IDEM-2374: Windows do not send the notification message when desktop …

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4665,12 +4665,7 @@ func (a *ServerWithRoles) UpdateWindowsDesktop(ctx context.Context, s types.Wind
 	if err := a.checkAccessToWindowsDesktop(s); err != nil {
 		return trace.Wrap(err)
 	}
-	err = a.authServer.UpdateWindowsDesktop(ctx, s)
-
-	if err == nil {
-		publishAppChanges(a.authServer, publisher.Desktop)
-	}
-	return err
+	return a.authServer.UpdateWindowsDesktop(ctx, s)
 }
 
 // UpsertWindowsDesktop updates a windows desktop resource, creating it if it doesn't exist.
@@ -4702,7 +4697,9 @@ func (a *ServerWithRoles) UpsertWindowsDesktop(ctx context.Context, s types.Wind
 		return trace.Wrap(err)
 	}
 	err = a.authServer.UpsertWindowsDesktop(ctx, s)
-	if err == nil {
+
+	// Publish notification only if the desktop added
+	if err == nil && len(existing) == 0 {
 		publishAppChanges(a.authServer, publisher.Desktop)
 	}
 	return err


### PR DESCRIPTION
…updated

- Send the notification when the desktop created or deleted.
- Do not send notification when the desktop is updated through
 - static host lists which uses the UpdateWindowsDesktop
 - dynamic sync which  uses the UpsertWindowsDesktop ( detect add or update here)