### PR TITLE
IDEM-2704: Encrypt cert authority using kms

### DIFF
--- a/assets/aws/files/bin/teleport-generate-config
+++ b/assets/aws/files/bin/teleport-generate-config
@@ -276,6 +276,7 @@ auth_service:
   app_publisher_config:
     enabled: true
     region: ${EC2_REGION}
+
   cluster_name: ${TELEPORT_CLUSTER_NAME}
 EOF
 
@@ -489,6 +490,9 @@ auth_service:
   app_publisher_config:
     enabled: true
     region: ${EC2_REGION}
+  kms_encryption_config:
+    region: ${EC2_REGION}
+    kms_key_id: ${KMS_KEY_ID}   
   cluster_name: ${TELEPORT_CLUSTER_NAME}
 EOF
 

--- a/examples/aws/cloudformation/idemeum.yaml
+++ b/examples/aws/cloudformation/idemeum.yaml
@@ -56,6 +56,11 @@ Parameters:
     Description: Number of days to keep audit events
     Type: Number
     Default: 365
+  
+  KmsKeyId:
+    Description: KMS Key Id to encrypt or decrypt the sensitive data
+    Type: "AWS::SSM::Parameter::Value<String>"
+    Default: "Services/Kms/IdemeumRemoteAccess-CMK-Arn",  
 
 Mappings:
 
@@ -196,6 +201,7 @@ Resources:
             USE_LETSENCRYPT=true
             IDEMEUM_TENANT=${Tenant}
             AUDIT_RETENTION_DAYS=${EventsRetentionDays}
+            KMS_KEY_ID=${KmsKeyId}
             EOF
 
             # Delete existing lock so that new instance can acquire lock.
@@ -293,6 +299,7 @@ Resources:
             USE_LETSENCRYPT=true
             IDEMEUM_TENANT=${Tenant}
             AUDIT_RETENTION_DAYS=${EventsRetentionDays}
+            KMS_KEY_ID=${KmsKeyId}
             EOF
 
             # Generate config and start proxy service

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -41,6 +41,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gravitational/teleport/lib/encryption"
 	"github.com/gravitational/teleport/lib/publisher"
 
 	"github.com/coreos/go-oidc/jose"
@@ -102,7 +103,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 	}
 
 	if cfg.Trust == nil {
-		cfg.Trust = local.NewCAService(cfg.Backend)
+		cfg.Trust = local.NewIdemeumCAService(cfg.Backend, cfg.EncryptionService)
 	}
 	if cfg.Presence == nil {
 		cfg.Presence = local.NewIdemeumPresenceService(cfg.Backend, cfg.AppPublisher)
@@ -212,6 +213,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		getClaimsFun:           getClaims,
 		inventory:              inventory.NewController(cfg.Presence),
 		AppPublisher:           cfg.AppPublisher,
+		EncryptionService:      cfg.EncryptionService,
 		RemoteAccessAppWatcher: publisher.NewIdemeumRemoteResourceWatcher(context.Background(), cfg.Events, cfg.AppPublisher),
 	}
 	for _, o := range opts {
@@ -385,6 +387,7 @@ type Server struct {
 
 	AppPublisher           publisher.AppPublisher
 	RemoteAccessAppWatcher *publisher.RemoteAccessAppWatcher
+	EncryptionService      encryption.EncryptionService
 }
 
 func (a *Server) CloseContext() context.Context {

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -635,6 +635,125 @@ func TestMigrateCertAuthorities(t *testing.T) {
 	}))
 }
 
+func TestEncryptCertAuthorities(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	as := newTestAuthServer(ctx, t)
+	clock := clockwork.NewFakeClock()
+	as.SetClock(clock)
+
+	for _, spec := range []types.CertAuthoritySpecV2{
+		{
+			Type:        types.HostCA,
+			ClusterName: "localhost",
+			ActiveKeys: types.CAKeySet{
+				SSH: []*types.SSHKeyPair{{
+					PrivateKey: []byte(fixtures.SSHCAPrivateKey),
+					PublicKey:  []byte(fixtures.SSHCAPublicKey),
+				}},
+				TLS: []*types.TLSKeyPair{{Cert: []byte(fixtures.TLSCACertPEM), Key: []byte(fixtures.TLSCAKeyPEM)}},
+			},
+			CheckingKeys: [][]byte{[]byte(fixtures.SSHCAPublicKey)},
+			SigningKeys:  [][]byte{[]byte(fixtures.SSHCAPrivateKey)},
+			TLSKeyPairs:  []types.TLSKeyPair{{Cert: []byte(fixtures.TLSCACertPEM), Key: []byte(fixtures.TLSCAKeyPEM)}},
+			Rotation:     nil,
+		},
+		{
+			Type:        types.UserCA,
+			ClusterName: "localhost",
+			ActiveKeys: types.CAKeySet{
+				SSH: []*types.SSHKeyPair{{
+					PrivateKey: []byte(fixtures.SSHCAPrivateKey),
+					PublicKey:  []byte(fixtures.SSHCAPublicKey),
+				}},
+				TLS: []*types.TLSKeyPair{{Cert: []byte(fixtures.TLSCACertPEM), Key: []byte(fixtures.TLSCAKeyPEM)}},
+			},
+			CheckingKeys: [][]byte{[]byte(fixtures.SSHCAPublicKey)},
+			SigningKeys:  [][]byte{[]byte(fixtures.SSHCAPrivateKey)},
+			TLSKeyPairs:  []types.TLSKeyPair{{Cert: []byte(fixtures.TLSCACertPEM), Key: []byte(fixtures.TLSCAKeyPEM)}},
+			Rotation:     &types.Rotation{State: types.RotationStateStandby},
+		},
+		{
+			Type:        types.JWTSigner,
+			ClusterName: "localhost",
+			ActiveKeys: types.CAKeySet{
+				JWT: []*types.JWTKeyPair{{PublicKey: []byte(fixtures.JWTSignerPublicKey), PrivateKey: []byte(fixtures.JWTSignerPrivateKey)}},
+			},
+			JWTKeyPairs: []types.JWTKeyPair{{PublicKey: []byte(fixtures.JWTSignerPublicKey), PrivateKey: []byte(fixtures.JWTSignerPrivateKey)}},
+			Rotation:    &types.Rotation{State: types.RotationStateStandby},
+		},
+	} {
+		t.Run(fmt.Sprintf("create %v CA", spec.Type), func(t *testing.T) {
+			ca, err := types.NewCertAuthority(spec)
+			require.NoError(t, err)
+			// Do NOT use services.MarshalCertAuthority to keep all fields as-is.
+			enc, err := utils.FastMarshal(ca)
+			require.NoError(t, err)
+
+			_, err = as.bk.Put(ctx, backend.Item{
+				Key:   backend.Key("authorities", string(ca.GetType()), ca.GetName()),
+				Value: enc,
+			})
+			require.NoError(t, err)
+		})
+	}
+
+	err := encryptCertAuthorities(ctx, as)
+	require.NoError(t, err)
+
+	var caSpecs []types.CertAuthoritySpecV2
+	for _, typ := range []types.CertAuthType{types.HostCA, types.UserCA, types.JWTSigner} {
+		t.Run(fmt.Sprintf("verify %v CA", typ), func(t *testing.T) {
+			cas, err := as.GetCertAuthorities(ctx, typ, true)
+			require.NoError(t, err)
+			require.Len(t, cas, 1)
+			caSpecs = append(caSpecs, cas[0].(*types.CertAuthorityV2).Spec)
+		})
+	}
+	require.Empty(t, cmp.Diff(caSpecs, []types.CertAuthoritySpecV2{
+		{
+			Type:        types.HostCA,
+			ClusterName: "localhost",
+			ActiveKeys: types.CAKeySet{
+				SSH: []*types.SSHKeyPair{{
+					PrivateKey: []byte(fixtures.SSHCAPrivateKey),
+					PublicKey:  []byte(fixtures.SSHCAPublicKey),
+				}},
+				TLS: []*types.TLSKeyPair{{Cert: []byte(fixtures.TLSCACertPEM), Key: []byte(fixtures.TLSCAKeyPEM)}},
+			},
+			CheckingKeys: [][]byte{[]byte(fixtures.SSHCAPublicKey)},
+			SigningKeys:  [][]byte{[]byte(fixtures.SSHCAPrivateKey)},
+			TLSKeyPairs:  []types.TLSKeyPair{{Cert: []byte(fixtures.TLSCACertPEM), Key: []byte(fixtures.TLSCAKeyPEM)}},
+			Rotation:     nil,
+		},
+		{
+			Type:        types.UserCA,
+			ClusterName: "localhost",
+			ActiveKeys: types.CAKeySet{
+				SSH: []*types.SSHKeyPair{{
+					PrivateKey: []byte(fixtures.SSHCAPrivateKey),
+					PublicKey:  []byte(fixtures.SSHCAPublicKey),
+				}},
+				TLS: []*types.TLSKeyPair{{Cert: []byte(fixtures.TLSCACertPEM), Key: []byte(fixtures.TLSCAKeyPEM)}},
+			},
+			CheckingKeys: [][]byte{[]byte(fixtures.SSHCAPublicKey)},
+			SigningKeys:  [][]byte{[]byte(fixtures.SSHCAPrivateKey)},
+			TLSKeyPairs:  []types.TLSKeyPair{{Cert: []byte(fixtures.TLSCACertPEM), Key: []byte(fixtures.TLSCAKeyPEM)}},
+			Rotation:     &types.Rotation{State: types.RotationStateStandby},
+		},
+		{
+			Type:        types.JWTSigner,
+			ClusterName: "localhost",
+			ActiveKeys: types.CAKeySet{
+				JWT: []*types.JWTKeyPair{{PublicKey: []byte(fixtures.JWTSignerPublicKey), PrivateKey: []byte(fixtures.JWTSignerPrivateKey)}},
+			},
+			JWTKeyPairs: []types.JWTKeyPair{{PublicKey: []byte(fixtures.JWTSignerPublicKey), PrivateKey: []byte(fixtures.JWTSignerPrivateKey)}},
+			Rotation:    &types.Rotation{State: types.RotationStateStandby},
+		},
+	}))
+}
+
 // Example resources generated using `tctl get all --with-secrets`.
 const (
 	hostCAYAML = `kind: cert_authority

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/encryption"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/suite"
 
@@ -282,6 +283,7 @@ func newTestAuthServer(ctx context.Context, t *testing.T, name ...string) *Serve
 		ClusterName:            clusterNameRes,
 		Backend:                bk,
 		Authority:              authority.New(),
+		EncryptionService:      &encryption.TestEncryptionService{},
 		SkipPeriodicOperations: true,
 	}
 	a, err := NewServer(authConfig)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -758,6 +758,20 @@ func applyAuditPublisherConfig(fc *FileConfig, cfg *service.Config) error {
 	return nil
 }
 
+func applyEncryptionConfig(fc *FileConfig, cfg *service.Config) error {
+	if fc.Auth.KMSEncryptionConfig == nil {
+		cfg.Auth.KMSEncryptionConfig.Region = ""
+		cfg.Auth.KMSEncryptionConfig.KmsKeyId = ""
+		return nil
+	}
+
+	cfg.Auth.KMSEncryptionConfig.Region = fc.Auth.KMSEncryptionConfig.Region
+	cfg.Auth.KMSEncryptionConfig.KmsKeyId = fc.Auth.KMSEncryptionConfig.KmsKeyId
+	cfg.Auth.KMSEncryptionConfig.ClusterName = cfg.Auth.ClusterName.GetClusterName()
+	cfg.Auth.KMSEncryptionConfig.Enabled = true
+	return nil
+}
+
 // applyProxyConfig applies file configuration for the "proxy_service" section.
 func applyProxyConfig(fc *FileConfig, cfg *service.Config) error {
 	var err error

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -720,6 +720,8 @@ type Auth struct {
 	AppPublisherConfig *AppPublisherConfig `yaml:"app_publisher_config,omitempty"`
 
 	AuditPublisherConfig *AuditPublisherConfig `yaml:"audit_publisher_config,omitempty"`
+
+	KMSEncryptionConfig *KMSEncryptionConfig `yaml:"kms_encryption_config,omitempty"`
 }
 
 type AppPublisherConfig struct {
@@ -734,6 +736,11 @@ type AuditPublisherConfig struct {
 	Region       string `yaml:"region,omitempty"`
 	// EventTypes audit event types are published using this publisher.
 	EventTypes apiutils.Strings `yaml:"event_types,omitempty"`
+}
+
+type KMSEncryptionConfig struct {
+	Region   string `yaml:"region,omitempty"`
+	KmsKeyId string `yaml:"km_key_id,omitempty"`
 }
 
 // CAKeyParams configures how CA private keys will be created and stored.

--- a/lib/encryption/encryptionservice.go
+++ b/lib/encryption/encryptionservice.go
@@ -1,0 +1,114 @@
+package encryption
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+)
+
+type EncryptionService interface {
+	Encrypt(text []byte) ([]byte, error)
+	Decrypt(data []byte) ([]byte, error)
+}
+
+type KMSEncryptionConfig struct {
+	ClusterName string
+	Region      string
+	KmsKeyId    string
+	Enabled     bool
+}
+
+func (cfg *KMSEncryptionConfig) CheckAndSetDefaults() error {
+	if !cfg.Enabled {
+		return nil
+	}
+
+	if cfg.ClusterName == "" {
+		log.Info("encryption service config cluster name is missing")
+		return trace.BadParameter("encryption service missing cluster name")
+	}
+
+	if cfg.Region == "" {
+		log.Info("encryption service config region is missing")
+		return trace.BadParameter("encryption service missing region")
+	}
+
+	if cfg.KmsKeyId == "" {
+		log.Info("encryption service config KmsKeyId is missing")
+		return trace.BadParameter("encryption service missing KmsKeyId")
+	}
+	return nil
+}
+
+func NewEncryptionService(config KMSEncryptionConfig) EncryptionService {
+	config.CheckAndSetDefaults()
+	if config.Enabled {
+		log.Info("Encryption service enabled")
+		return newKMSEncryptionService(config)
+	}
+
+	log.Info("Encryption service not enabled")
+	return nil
+}
+
+type kmsEncryptionService struct {
+	kmsService *kms.KMS
+	cfg        KMSEncryptionConfig
+}
+
+func newKMSEncryptionService(cfg KMSEncryptionConfig) EncryptionService {
+	log.Info("Initializing the kms server")
+	session := session.Must(session.NewSession(&aws.Config{
+		Region: &cfg.Region,
+	}))
+
+	kmsService := kms.New(session)
+	log.Info("Initialized the sqs app publisher service")
+	return &kmsEncryptionService{kmsService, cfg}
+}
+
+func (s *kmsEncryptionService) Encrypt(text []byte) ([]byte, error) {
+	result, err := s.kmsService.Encrypt(&kms.EncryptInput{
+		KeyId:             aws.String(s.cfg.KmsKeyId),
+		Plaintext:         []byte(text),
+		EncryptionContext: getEncryptionContext(s.cfg.ClusterName),
+	})
+
+	return result.CiphertextBlob, err
+}
+
+// Decrypt implements EncryptionService
+func (s *kmsEncryptionService) Decrypt(data []byte) ([]byte, error) {
+	result, err := s.kmsService.Decrypt(&kms.DecryptInput{
+		KeyId:             aws.String(s.cfg.KmsKeyId),
+		CiphertextBlob:    []byte(data),
+		EncryptionContext: getEncryptionContext(s.cfg.ClusterName),
+	})
+
+	return result.Plaintext, err
+}
+
+type TestEncryptionService struct {
+}
+
+// Encrypt implements EncryptionService
+func (*TestEncryptionService) Encrypt(data []byte) ([]byte, error) {
+	log.Info("encrypting")
+	encrypted := string("test") + string(data)
+	return []byte(encrypted), nil
+}
+
+// Decrypt implements EncryptionService
+func (*TestEncryptionService) Decrypt(data []byte) ([]byte, error) {
+	log.Info("decrypting")
+	//remove "test"
+	return data[4:], nil
+}
+
+func getEncryptionContext(ClusterName string) map[string]*string {
+	encryptionContext := make(map[string]*string)
+	encryptionContext["clusterName"] = aws.String(ClusterName)
+	return encryptionContext
+}

--- a/lib/encryption/itemencrypter.go
+++ b/lib/encryption/itemencrypter.go
@@ -1,0 +1,97 @@
+package encryption
+
+import (
+	"encoding/json"
+
+	"github.com/cloudflare/cfssl/log"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/trace"
+)
+
+type ItemEncrypter interface {
+	Encrypt(item *backend.Item) (*backend.Item, error)
+	Decrypt(item *backend.Item) (*backend.Item, error)
+}
+
+type itemEncrypter struct {
+	es EncryptionService
+}
+
+func NewItemEncryptionService(es EncryptionService) ItemEncrypter {
+	log.Infof("initializing item encryption service: %v", es)
+	return &itemEncrypter{es: es}
+}
+
+func (s *itemEncrypter) Encrypt(item *backend.Item) (*backend.Item, error) {
+	if s.es != nil {
+		itemEncryptedValue, err := s.es.Encrypt(item.Value)
+		if err != nil {
+			return item, trace.Wrap(err)
+		}
+		encryptedValue, err := json.Marshal(EncryptedValue{
+			Value:     itemEncryptedValue,
+			Encrypted: true,
+		})
+
+		if err != nil {
+			return item, trace.Wrap(err)
+		}
+
+		newItem := &backend.Item{
+			Key:     item.Key,
+			Value:   encryptedValue,
+			Expires: item.Expires,
+			ID:      item.ID,
+			LeaseID: item.LeaseID,
+		}
+		return newItem, nil
+
+	}
+	return item, nil
+}
+
+func (s *itemEncrypter) Decrypt(item *backend.Item) (*backend.Item, error) {
+	encryptedValue, err := ToEncryptedValue(item.Value)
+	if err != nil {
+		return item, trace.Wrap(err)
+	}
+
+	if !encryptedValue.Encrypted {
+		return item, nil
+	}
+
+	if encryptedValue.Encrypted && s.es == nil {
+		return item, trace.BadParameter("trust service missing encryption service")
+	}
+
+	value, err := s.es.Decrypt(encryptedValue.Value)
+	if err != nil {
+		return item, err
+	}
+	newItem := &backend.Item{
+		Key:     item.Key,
+		Value:   value,
+		Expires: item.Expires,
+		ID:      item.ID,
+		LeaseID: item.LeaseID,
+	}
+	return newItem, nil
+}
+
+type EncryptedValue struct {
+	Value     []byte
+	Encrypted bool
+}
+
+func ToEncryptedValue(data []byte) (EncryptedValue, error) {
+	if !json.Valid(data) {
+		return EncryptedValue{Value: data, Encrypted: false}, nil
+	}
+
+	encryptedValue := EncryptedValue{}
+	err := json.Unmarshal(data, &encryptedValue)
+	if err != nil {
+		return EncryptedValue{}, trace.Wrap(err)
+	}
+	return encryptedValue, nil
+}

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gravitational/teleport/lib/encryption"
 	"github.com/gravitational/teleport/lib/publisher"
 
 	"github.com/gravitational/teleport"
@@ -579,6 +580,9 @@ type AuthConfig struct {
 
 	// AuditPublisherConfig config to publish the audit events
 	AuditPublisherConfig publisher.AuditPublisherConfig
+
+	// encryption service configuration to encryp the cert authority
+	KMSEncryptionConfig encryption.KMSEncryptionConfig
 }
 
 // SSHConfig configures SSH server node role

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -42,6 +42,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/gravitational/teleport/lib/encryption"
 	"github.com/gravitational/teleport/lib/publisher"
 
 	"github.com/gravitational/teleport"
@@ -1513,6 +1514,7 @@ func (process *TeleportProcess) initAuthService() error {
 		Emitter:                 checkingEmitter,
 		Streamer:                events.NewReportingStreamer(checkingStreamer, process.Config.UploadEventsC),
 		AppPublisher:            publisher.NewAppPublisher(cfg.Auth.AppPublisherConfig),
+		EncryptionService:       encryption.NewEncryptionService(cfg.Auth.KMSEncryptionConfig),
 		TenantUrl:               cfg.TenantUrl,
 		IdemeumPresetsEnabled:   cfg.IdemeumPresetsEnabled,
 	})

--- a/lib/services/local/resource_test.go
+++ b/lib/services/local/resource_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
+	"github.com/gravitational/teleport/lib/encryption"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/suite"
 
@@ -139,7 +140,7 @@ func (r *ResourceSuite) TestCertAuthorityResource(c *check.C) {
 	// Check basic dynamic item creation
 	r.runCreationChecks(c, userCA, hostCA)
 	// Check that dynamically created item is compatible with service
-	s := NewCAService(r.bk)
+	s := NewIdemeumCAService(r.bk, encryption.NewEncryptionService(encryption.KMSEncryptionConfig{}))
 	err := s.CompareAndSwapCertAuthority(userCA, userCA)
 	c.Assert(err, check.IsNil)
 }


### PR DESCRIPTION
1.We have added encryption service which will provide the encryption
  for the sensitive data i.e cert authority CA data
2. Added KMS based encryption and test encryption for test purpose
3. Added the encryption support for CertAuthority database item when its saved to DB or read from DB to minimize the changes as the CertAuthority object is used across multiple places
4. Added logic to encrypt the existing CertAuthority value as JSON to indicate whether the data is encrypted or not, using this during the DB load we will decide to decrypt the data or not.