### PR TITLE
IDEM-1799: logging out of idemeum logs out from teleport

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -62,6 +62,10 @@ func (a *ServerWithRoles) ValidateIdemeumServiceToken(ctx context.Context, Servi
 	return a.authServer.ValidateIdemeumServiceToken(ctx, ServiceToken, TenantUrl)
 }
 
+func (a *ServerWithRoles) GetUserSessions(ctx context.Context, UserId string, DeviceId string, TokenId string) ([]types.WebSession, error) {
+	return a.authServer.GetUserSessions(ctx, UserId, DeviceId, TokenId)
+}
+
 // CloseContext is closed when the auth server shuts down
 func (a *ServerWithRoles) CloseContext() context.Context {
 	return a.authServer.closeCtx

--- a/lib/encryption/encryptionservice.go
+++ b/lib/encryption/encryptionservice.go
@@ -65,7 +65,7 @@ func newKMSEncryptionService(cfg KMSEncryptionConfig) EncryptionService {
 	}))
 
 	kmsService := kms.New(session)
-	log.Info("Initialized the sqs app publisher service")
+	log.Info("Initialized the kms encryption service")
 	return &kmsEncryptionService{kmsService, cfg}
 }
 

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -604,6 +604,13 @@ func (s *sessionCache) ValidateServiceToken(ctx context.Context, ServiceToken st
 	return s.proxyClient.ValidateIdemeumServiceToken(ctx, ServiceToken, TenantUrl)
 }
 
+func (s *sessionCache) GetUserSessions(ctx context.Context, UserId string, DeviceId string, TokenId string) ([]types.WebSession, error) {
+	log.Infof("Getting the active sessions for user %v from device %v for token %v", UserId, DeviceId, TokenId)
+
+	//get all the active sessions for ths user
+	return s.proxyClient.GetUserSessions(ctx, UserId, DeviceId, TokenId)
+}
+
 // GetCertificateWithoutOTP returns a new user certificate for the specified request.
 func (s *sessionCache) GetCertificateWithoutOTP(
 	c client.CreateSSHCertReq, clientMeta *auth.ForwardedClientMetadata,


### PR DESCRIPTION
When logging out of idemeum we are posting a message to teleport to logout user from teleport.

This PR: https://github.com/idemeum/appmanagement/pull/1595 has the app management changes. AppManagement will post as message with userId, deviceId and tokenId to /webapi//idp/logout 

This api will get the user and will try to get all the user's sessions by making a call to Auth Proxy new endpoint /user/sessions

This API's implementation is rudimentary as of now: it gets all the web sessions and then it filters out only the sessions for this user and returns them. 

Now on the Proxy service we have the web sessions and we just call invalidate on all those sessions. 

If you want to test you can onboard to localgeorge6.idemeumlab.com (for Ashok and Kamlesh I have used your idemeum email and for Sachin the gmail). There are 3 apps: SonarQube (admin/idemeum), Grafana (admin/admin) and a remote server. You can launch all of these ones, log in and then log out from Idemeum. You need to onboard first so I can entitle you. 

NOTE:
1. I am working on adding tests
2. Are you guys using a different formatter as I see some formatting changes