### PR TITLE
IDEM-2704: Part3 disable the kms encryption

### DIFF
--- a/assets/aws/files/bin/teleport-generate-config
+++ b/assets/aws/files/bin/teleport-generate-config
@@ -275,10 +275,7 @@ auth_service:
     region: ${EC2_REGION}
   app_publisher_config:
     enabled: true
-    region: ${EC2_REGION}
-  kms_encryption_config:
-    region: ${EC2_REGION}
-    kms_key_id: ${KMS_KEY_ID}   
+    region: ${EC2_REGION}  
   cluster_name: ${TELEPORT_CLUSTER_NAME}
 EOF
 
@@ -492,9 +489,6 @@ auth_service:
   app_publisher_config:
     enabled: true
     region: ${EC2_REGION} 
-  kms_encryption_config:
-    region: ${EC2_REGION}
-    kms_key_id: ${KMS_KEY_ID}
   cluster_name: ${TELEPORT_CLUSTER_NAME}      
 EOF
 


### PR DESCRIPTION
- We have hit the plainText limit where as kms only encrypts upto 4k bytes, while the cert authority object is more than 4k.
- Disabling the kms encryption until we found solution to this issue