### PR TITLE
IDEM-2864: added a tenant-url to the login command

### DIFF
--- a/tool/tsh/help.go
+++ b/tool/tsh/help.go
@@ -24,17 +24,15 @@ import (
 const (
 	// loginUsageFooter is printed at the bottom of `tsh help login` output
 	loginUsageFooter = `NOTES:
-  The --proxy is the url of your Remote Access server. E.g (acme.remote.idemeum.com)
+  The tenant-url is the url of your Idemeum tenant. E.g (acme.idemeum.com)
 
 EXAMPLES:
   Will get an authentication token for your user to be able to login to your company's remote servers. 
-  $ tsh --proxy=acme.remote.idemeum.com login`
+  $ tsh login --tenant-url=acme.idemeum.com`
 
 	// missingPrincipalsFooter is printed at the bottom of `tsh ls` when no results are returned.
 	missingPrincipalsFooter = `
-  Not seeing nodes? Your user may be missing Linux principals. If trying teleport for the first time, follow this guide:
-
-https://goteleport.com/docs/getting-started/linux-server/#step-46-create-a-teleport-user-and-set-up-two-factor-authentication
+  Not seeing nodes? Your user may be missing Linux principals. Make sure you do have remote servers accessible to you in your Idemeum portal.
   `
 )
 


### PR DESCRIPTION
Comment out the --proxy flag at the tsh level and added the tenant-url flag for the login command.

georgeoprean@george build % ./tsh help login
usage: tsh login [<flags>]

Log in to a Remote Access server and retrieve the session certificate

Flags:
  -l, --login                    Remote host login
      --ttl                      Minutes to live for a SSH session
  -i, --identity                 Identity file
      --cert-format              SSH certificate format
      --insecure                 Do not verify server's certificate and host name. Use only in test environments
      --skip-version-check       Skip version checking between server and client.
  -d, --debug                    Verbose logging to stdout
  -k, --add-keys-to-agent        Controls how keys are handled. Valid values are [auto no yes only].
      --enable-escape-sequences  Enable support for SSH escape sequences. Type '~?' during an SSH session to list supported sequences. Default is enabled.
      --bind-addr                Override host:port used when opening a browser for Remote Access logins
      --tenant-url               Idemeum portal url (e.g: acme.idemeum.com)
  -o, --out                      Identity output
  -f, --format                   Identity format: file, openssh (for OpenSSH compatibility)
      --overwrite                Whether to overwrite the existing identity file.
      --browser                  Set to 'none' to suppress browser opening on login

Aliases:
NOTES:
  The tenant-url is the url of your Idemeum tenant. E.g (acme.idemeum.com)

EXAMPLES:
  Will get an authentication token for your user to be able to login to your company's remote servers.
  $ tsh login --tenant-url=acme.idemeum.com


Example of response when tenant-url is not passed in:
georgeoprean@george build % ./tsh login
ERROR: Missing tenant-url parameter.

Example of response when the tenant-url does not have 3 parts (not we are not checking if it is a valid url or not)
georgeoprean@george build % ./tsh login --tenant-url=google.com
ERROR: tenant-url does not seem to be a valid Idemeum url (e.g: acme.idemeum.com is a valid Idemeum tenant url)

Example of response when tenant-url is set correctly:
georgeoprean@george build % ./tsh login --tenant-url=dev.idemeumlab.com
If browser window does not open automatically, open it by clicking on the link:
 http://127.0.0.1:51344/4757906a-f492-4c0a-bb6e-7eba3d262d63
> Profile URL:        https://dev.remote.idemeumlab.com:443
  Logged in as:       did:dvmi:dc3393a2-bc87-432e-94f4-522172e99c03
  Cluster:            dev.remote.idemeumlab.com
  Roles:              ADMIN, USER
  Logins:             ec2-user, root, demo, -teleport-internal-join
  Kubernetes:         enabled
  Valid until:        2023-04-20 03:17:37 +0300 EEST [valid for 12h0m0s]
  Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty