### PR TITLE
IDEM-2865: part2 - only display a handful of info after the login completes

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -74,6 +74,8 @@ type Profile struct {
 	// email of the idemeum user
 	Email string `yaml:"email,omitempty"`
 	
+	// idemeum tenant url
+	IdemeumTenantUrl string `yaml:"idemeum_tenant_url,omitempty"`
 	// AuthType (like "google")
 	AuthType string `yaml:"auth_type,omitempty"`
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -174,6 +174,8 @@ type Config struct {
 	Username string
 	// email set in idemeum
 	Email string
+	// idemeum tenant url
+	IdemeumTenantUrl string
 	// ExplicitUsername is true if Username was initially set by the end-user
 	// (for example, using command-line flags).
 	ExplicitUsername bool
@@ -509,6 +511,9 @@ type ProfileStatus struct {
 	// Email of the user that logged in
 	Email string
 
+	// the url of the idemeum tenant
+	IdemeumTenantUrl string
+
 	// Roles is a list of Teleport Roles this user has been assigned.
 	Roles []string
 
@@ -772,6 +777,7 @@ type ProfileOptions struct {
 	WebProxyAddr  string
 	Username      string
 	Email 		  string
+	IdemeumTenantUrl string
 	SiteName      string
 	KubeProxyAddr string
 	IsVirtual     bool
@@ -877,6 +883,7 @@ func profileFromKey(key *Key, opts ProfileOptions) (*ProfileStatus, error) {
 		},
 		Username:           opts.Username,
 		Email:			    opts.Email, 
+		IdemeumTenantUrl:   opts.IdemeumTenantUrl,
 		Logins:             sshCert.ValidPrincipals,
 		ValidUntil:         validUntil,
 		Extensions:         extensions,
@@ -960,6 +967,7 @@ func ReadProfileStatus(profileDir string, profileName string) (*ProfileStatus, e
 		WebProxyAddr:  profile.WebProxyAddr,
 		Username:      profile.Username,
 		Email: 	       profile.Email,
+		IdemeumTenantUrl: profile.IdemeumTenantUrl ,	
 		SiteName:      profile.SiteName,
 		KubeProxyAddr: profile.KubeProxyAddr,
 		IsVirtual:     false,
@@ -1146,6 +1154,7 @@ func (c *Config) SaveProfile(dir string, makeCurrent bool) error {
 	var cp profile.Profile
 	cp.Username = c.Username
 	cp.Email = c.Email
+	cp.IdemeumTenantUrl = c.IdemeumTenantUrl
 	cp.WebProxyAddr = c.WebProxyAddr
 	cp.SSHProxyAddr = c.SSHProxyAddr
 	cp.KubeProxyAddr = c.KubeProxyAddr

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -3004,6 +3004,7 @@ func makeClientForProxy(cf *CLIConf, proxy string, useProfileLogin bool) (*clien
 	tc.Config.Reason = cf.Reason
 	tc.Config.Invited = cf.Invited
 	tc.Config.DisplayParticipantRequirements = cf.displayParticipantRequirements
+	tc.IdemeumTenantUrl = cf.IdemeumTenantUrl
 	return tc, nil
 }
 
@@ -3168,7 +3169,7 @@ func onShow(cf *CLIConf) error {
 
 // printStatus prints the status of the profile.
 func printStatus(debug bool, p *client.ProfileStatus, isActive bool) {
-	var count int
+	// var count int
 	var prefix string
 	if isActive {
 		prefix = "> "
@@ -3181,53 +3182,53 @@ func printStatus(debug bool, p *client.ProfileStatus, isActive bool) {
 		humanDuration = fmt.Sprintf("valid for %v", duration.Round(time.Minute))
 	}
 
-	fmt.Printf("%vProfile URL:        %v\n", prefix, p.ProxyURL.String())
+	fmt.Printf("%vIdemeum Tenant:     %v\n", prefix, p.IdemeumTenantUrl)
 	fmt.Printf("  Logged in as:       %v\n", p.Email)
-	if len(p.ActiveRequests.AccessRequests) != 0 {
-		fmt.Printf("  Active requests:    %v\n", strings.Join(p.ActiveRequests.AccessRequests, ", "))
-	}
-	if p.Cluster != "" {
-		fmt.Printf("  Cluster:            %v\n", p.Cluster)
-	}
-	fmt.Printf("  Roles:              %v\n", strings.Join(p.Roles, ", "))
-	if debug {
-		for k, v := range p.Traits {
-			if count == 0 {
-				fmt.Printf("  Traits:             %v: %v\n", k, v)
-			} else {
-				fmt.Printf("                      %v: %v\n", k, v)
-			}
-			count = count + 1
-		}
-	}
-	fmt.Printf("  Logins:             %v\n", strings.Join(p.Logins, ", "))
-	if p.KubeEnabled {
-		fmt.Printf("  Kubernetes:         enabled\n")
-		if kubeCluster := selectedKubeCluster(p.Cluster); kubeCluster != "" {
-			fmt.Printf("  Kubernetes cluster: %q\n", kubeCluster)
-		}
-		if len(p.KubeUsers) > 0 {
-			fmt.Printf("  Kubernetes users:   %v\n", strings.Join(p.KubeUsers, ", "))
-		}
-		if len(p.KubeGroups) > 0 {
-			fmt.Printf("  Kubernetes groups:  %v\n", strings.Join(p.KubeGroups, ", "))
-		}
-	} else {
-		fmt.Printf("  Kubernetes:         disabled\n")
-	}
-	if len(p.Databases) != 0 {
-		fmt.Printf("  Databases:          %v\n", strings.Join(p.DatabaseServices(), ", "))
-	}
-	if len(p.AllowedResourceIDs) > 0 {
-		allowedResourcesStr, err := types.ResourceIDsToString(p.AllowedResourceIDs)
-		if err != nil {
-			log.Warnf("failed to marshal allowed resource IDs to string: %v", err)
-		} else {
-			fmt.Printf("  Allowed Resources:  %s\n", allowedResourcesStr)
-		}
-	}
+	// if len(p.ActiveRequests.AccessRequests) != 0 {
+	// 	fmt.Printf("  Active requests:    %v\n", strings.Join(p.ActiveRequests.AccessRequests, ", "))
+	// }
+	// if p.Cluster != "" {
+	// 	fmt.Printf("  Cluster:            %v\n", p.Cluster)
+	// }
+	// fmt.Printf("  Roles:              %v\n", strings.Join(p.Roles, ", "))
+	// if debug {
+	// 	for k, v := range p.Traits {
+	// 		if count == 0 {
+	// 			fmt.Printf("  Traits:             %v: %v\n", k, v)
+	// 		} else {
+	// 			fmt.Printf("                      %v: %v\n", k, v)
+	// 		}
+	// 		count = count + 1
+	// 	}
+	// }
+	// fmt.Printf("  Logins:             %v\n", strings.Join(p.Logins, ", "))
+	// if p.KubeEnabled {
+	// 	fmt.Printf("  Kubernetes:         enabled\n")
+	// 	if kubeCluster := selectedKubeCluster(p.Cluster); kubeCluster != "" {
+	// 		fmt.Printf("  Kubernetes cluster: %q\n", kubeCluster)
+	// 	}
+	// 	if len(p.KubeUsers) > 0 {
+	// 		fmt.Printf("  Kubernetes users:   %v\n", strings.Join(p.KubeUsers, ", "))
+	// 	}
+	// 	if len(p.KubeGroups) > 0 {
+	// 		fmt.Printf("  Kubernetes groups:  %v\n", strings.Join(p.KubeGroups, ", "))
+	// 	}
+	// } else {
+	// 	fmt.Printf("  Kubernetes:         disabled\n")
+	// }
+	// if len(p.Databases) != 0 {
+	// 	fmt.Printf("  Databases:          %v\n", strings.Join(p.DatabaseServices(), ", "))
+	// }
+	// if len(p.AllowedResourceIDs) > 0 {
+	// 	allowedResourcesStr, err := types.ResourceIDsToString(p.AllowedResourceIDs)
+	// 	if err != nil {
+	// 		log.Warnf("failed to marshal allowed resource IDs to string: %v", err)
+	// 	} else {
+	// 		fmt.Printf("  Allowed Resources:  %s\n", allowedResourcesStr)
+	// 	}
+	// }
 	fmt.Printf("  Valid until:        %v [%v]\n", p.ValidUntil, humanDuration)
-	fmt.Printf("  Extensions:         %v\n", strings.Join(p.Extensions, ", "))
+	// fmt.Printf("  Extensions:         %v\n", strings.Join(p.Extensions, ", "))
 
 	if debug {
 		first := true


### PR DESCRIPTION
After the loging completes (and it will be the same output for the status command) we only need to display a handful of information to the user. So ignored all the other messages that were displayed and kept it to the minimum. 

I have added the Idemeum tenant url since the proxy cluster did not had any meaning to the user. 

Here is an example of how it will look after a login message

**georgeoprean@george build % ./tsh login --tenant-url=georgelocal6.idemeumlab.com
If browser window does not open automatically, open it by clicking on the link:
 http://127.0.0.1:64926/1ff6386b-8358-4fbe-b9bb-25c06ee13def
> Idemeum Tenant:     georgelocal6.idemeumlab.com
  Logged in as:       goprean@gmail.com
  Valid until:        2023-04-21 23:51:31 +0300 EEST [valid for 6h19m0s]**