### PR TITLE
IDEM-2874: limit the ssh certificate duration to 1h if no ttl is passed

### DIFF
--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -2669,9 +2669,13 @@ func makeClientForProxy(cf *CLIConf, proxy string, useProfileLogin bool) (*clien
 		return nil, trace.Wrap(err)
 	}
 
-	// apply defaults
+	// apply defaults (by default only issue a certificate for 1 hour)
 	if cf.MinsToLive == 0 {
-		cf.MinsToLive = int32(apidefaults.CertDuration / time.Minute)
+		cf.MinsToLive = int32(60)
+	}
+
+	if (cf.MinsToLive > int32(apidefaults.CertDuration / time.Minute)) {
+		return nil, trace.BadParameter("Maximum ttl allowed is 12hours (720 minutes)")		
 	}
 
 	// split login & host


### PR DESCRIPTION
The login command has an option to pass a ttl (in minutes).
If no ttl is passed then it will default to 12 hours (transformed in minutes). 

To prevent the certificate from being stolen, limit the duration of the cert when it is issued to 12 hours. If no ttl is passed in then the cert will only be valid for 60 mins. 

If the user already has a session with idemeum or if the session for idemeum is set to 8 hours and the user asks for a cert t be valid for 10 hours, then the cert issue will only be valid for 8 hours. 

The ssh cert will never be expire after the idemeum session expired. For example let's assume that a tenant has the idemeum session set for 8 hours. And a user has been logged in 7h:30 mins ago. 
When this user requests for a ssh cert (by executing the ./tsh login command) the cert will be valid for 30 mins even if the user asks for a certificate with a ttl command option of 5 hours. 


**georgeoprean@george build % ./tsh logout**
Logged out all users from all proxies.

**georgeoprean@george build % ./tsh login --tenant-url=georgelocal6.idemeumlab.com**
If browser window does not open automatically, open it by clicking on the link:
 http://127.0.0.1:65480/4ec0df26-ec33-4581-b44b-b07254611501
> Idemeum Tenant:     georgelocal6.idemeumlab.com
  Logged in as:       goprean@gmail.com
  **Valid until:        2023-04-27 18:55:42 +0300 EEST [valid for 1h0m0s]**