### PR TITLE
IDEM-2877: build the script as ish instead of tsh

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	// profileDir is the default root directory where tsh stores profiles.
-	profileDir = ".tsh"
+	profileDir = ".ish"
 	// currentProfileFilename is a file which stores the name of the
 	// currently active profile.
 	currentProfileFilename = "current-profile"

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -539,7 +539,7 @@ func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, pty *os.Fi
 	// If the server allows reading in of ~/.tsh/environment read it in
 	// and pass environment variables along to new session.
 	if c.PermitUserEnvironment {
-		filename := filepath.Join(localUser.HomeDir, ".tsh", "environment")
+		filename := filepath.Join(localUser.HomeDir, ".ish", "environment")
 		userEnvs, err := utils.ReadEnvironmentFile(filename)
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -457,7 +457,7 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 	var cpuProfile, memProfile string
 
 	// configure CLI argument parser:
-	app := utils.InitCLIParser("tsh", "Idemeum Command Line Client").Interspersed(false)
+	app := utils.InitCLIParser("ish", "Idemeum Command Line Client").Interspersed(false)
 	app.Flag("login", "Remote host login").Short('l').Envar(loginEnvVar).StringVar(&cf.NodeLogin)
 	// localUser, _ := client.Username()
 	// app.Flag("proxy", "SSH proxy address").Envar(proxyEnvVar).StringVar(&cf.Proxy)

--- a/tool/tsh/tshconfig_test.go
+++ b/tool/tsh/tshconfig_test.go
@@ -67,7 +67,7 @@ func TestLoadAllConfigs(t *testing.T) {
 		}},
 	}
 
-	homeDir := path.Join(tmp, "home", "myuser", ".tsh")
+	homeDir := path.Join(tmp, "home", "myuser", ".ish")
 	userPath := path.Join(homeDir, "config", "config.yaml")
 	userConf := TshConfig{
 		ExtraHeaders: []ExtraProxyHeaders{{


### PR DESCRIPTION
Rename the script from tsh to ish. 
When you need to build the ish script locally from teleport git repo you now can run: make build/ish 

