### PR TITLE
IDEM-2880: do not retain the remote access tables when a stack is deleted

### DIFF
--- a/examples/aws/cloudformation/idemeum.yaml
+++ b/examples/aws/cloudformation/idemeum.yaml
@@ -1044,7 +1044,6 @@ Resources:
   # where teleport stores all relevant state
   MainTable:
     Type: AWS::DynamoDB::Table
-    DeletionPolicy: Retain
     Properties:
       TableName: !Join ["_", [RemoteAccessMain, !Ref TenantName]]
       BillingMode: PAY_PER_REQUEST
@@ -1085,7 +1084,6 @@ Resources:
   # trying to renew and manage letsencrypt certificate
   LocksTable:
     Type: AWS::DynamoDB::Table
-    DeletionPolicy: Delete
     Properties:
       TableName: !Join ["_", [RemoteAccessLocks, !Ref TenantName]]
       BillingMode: PAY_PER_REQUEST
@@ -1116,7 +1114,6 @@ Resources:
 
   EventsTable:
     Type: AWS::DynamoDB::Table
-    DeletionPolicy: Retain
     Properties:
       TableName: !Join ["_", [RemoteAccessEvents, !Ref TenantName]]
       BillingMode: PAY_PER_REQUEST


### PR DESCRIPTION
When we will automatically delete the stack (either by calling a devops REST API or by the automatic tenant cleanup process) we don't want the tables with remote access events to be still in DynamoDb. 

With the automatic cleanup, we keep the customer data for up to 30 days. After that we will delete all the data, including the remote access events, locks, sessions. 

The only resource that we will still have to keep as DeletionPolicy: Retain is the s3 bucket since Cloud formation cannot delete non empty buckets. We will delete those buckets manually in code. 