### PR TITLE
IDEM-2953: added v2 of the config file and set the proxy listener mode to multiplex

### DIFF
--- a/assets/aws/files/bin/teleport-generate-config
+++ b/assets/aws/files/bin/teleport-generate-config
@@ -237,6 +237,7 @@ if [[ "${TELEPORT_ROLE}" == "auth" ]]; then
     # Teleport Auth server is using DynamoDB as a backend
     # On AWS, see dynamodb.tf for details
     cat >${USE_CONFIG_PATH} <<EOF
+version: v2    
 tenant_url: https://${IDEMEUM_TENANT}
 idemeum_presets_enabled: true
 teleport:
@@ -265,6 +266,7 @@ auth_service:
   keep_alive_interval: 1m
   keep_alive_count_max: 3
   listen_addr: 0.0.0.0:3025
+  proxy_listener_mode: multiplex
   authentication:
     type: saml
     local_auth: true
@@ -316,6 +318,7 @@ elif [[ "${TELEPORT_ROLE}" == "proxy" ]]; then
     # Teleport proxy proxies and optionally records
     # SSH sessions
     cat >${USE_CONFIG_PATH} <<EOF
+version: v2
 tenant_url: https://${IDEMEUM_TENANT}
 idemeum_presets_enabled: true
 teleport:

--- a/assets/aws/files/install.sh
+++ b/assets/aws/files/install.sh
@@ -81,7 +81,7 @@ else
             curl ${CURL_OPTS} -o teleport.tar.gz https://asset.idemeumlab.com/teleport/${TELEPORT_VERSION}/teleport-v${TELEPORT_VERSION}-linux-amd64-bin.tar.gz
         fi
         tar -xzf teleport.tar.gz
-        cp teleport/tctl teleport/tsh teleport/teleport /usr/local/bin
+        cp teleport/tctl teleport/ish teleport/teleport /usr/local/bin
         rm -rf /tmp/teleport.tar.gz /tmp/teleport
     else
         TARBALL_FILENAME="/tmp/files/teleport-ent-v${TELEPORT_VERSION}-linux-amd64-bin.tar.gz"


### PR DESCRIPTION
In order to allow just one port to handle multiple application protocols (http, ssh, sql, etc) we need to set the proxy_listener_mode attribute to multiplex on the auth_service.
Also explicitly set v2 as the configuration version file.