### PR TITLE
IDEM-2955: Do not expose port 3023 on the security group

### DIFF
--- a/assets/aws/files/bin/teleport-generate-config
+++ b/assets/aws/files/bin/teleport-generate-config
@@ -150,7 +150,8 @@ EOS
 
 write_ssh_and_tunnel_section() {
     PASSED_EXTERNAL_TUNNEL_PORT="$1"
-    SSH_PORT=3023
+    # idemeum always uses TLS routing so the only export port is 443
+    SSH_PORT=443 
     POSTGRES_PORT=443
     if [[ "${TELEPORT_PROXY_SERVER_LB}" != "" ]]; then
         # ACM

--- a/examples/aws/cloudformation/idemeum.yaml
+++ b/examples/aws/cloudformation/idemeum.yaml
@@ -462,11 +462,6 @@ Resources:
       VpcId: '{{resolve:ssm:/Services/VPC/Id}}'
       SecurityGroupIngress:
         - IpProtocol: tcp
-          Description: Port for SSH clients
-          FromPort: 3023
-          ToPort: 3023
-          CidrIp: 0.0.0.0/0
-        - IpProtocol: tcp
           Description: Port for HTTPS connections
           FromPort: !If [HighAvailablity, '3080', '443']
           ToPort: !If [HighAvailablity, '3080', '443']


### PR DESCRIPTION
All the teleport deployments will use TLS routing. So only port 443 is exposed on the proxy server to the outside world. 
Remove port 3023 from the security group on the proxy server. 
Also set the ssh_public_addr port to 443 instead of 3023